### PR TITLE
Changing file size detection to support symlinks

### DIFF
--- a/gui/computeWhitening.m
+++ b/gui/computeWhitening.m
@@ -22,8 +22,8 @@ rez.ycoords = yc;
 rez.ops.chanMap = chanMap;
 rez.ops.kcoords = kcoords; 
 
-d = dir(ops.fbinary);
-nTimepoints = floor(d.bytes/NchanTOT/2);
+bytes = get_file_size(ops.fbinary);
+nTimepoints = floor(bytes/NchanTOT/2);
 
 rez.ops.tstart = ceil(ops.trange(1) * ops.fs); 
 rez.ops.tend   = min(nTimepoints, ceil(ops.trange(2) * ops.fs)); 

--- a/gui/ksGUI.m
+++ b/gui/ksGUI.m
@@ -572,8 +572,7 @@ classdef ksGUI < handle
             
             if ~isempty(obj.H.settings.ChooseFileEdt.String) && ...
                     ~strcmp(obj.H.settings.ChooseFileEdt.String, '...')
-                d = dir(obj.H.settings.ChooseFileEdt.String);
-                b = d.bytes;
+                b = get_file_size(obj.H.settings.ChooseFileEdt.String);
 
                 a = cast(0, 'int16'); % hard-coded for now, int16
                 q = whos('a');

--- a/preProcess/preprocessDataSub.m
+++ b/preProcess/preprocessDataSub.m
@@ -6,11 +6,11 @@ ops.nt0min  = getOr(ops, 'nt0min', ceil(20 * ops.nt0/61));
 NT       = ops.NT ;
 NchanTOT = ops.NchanTOT;
 
-d = dir(ops.fbinary);
-nTimepoints = floor(d.bytes/NchanTOT/2);
-ops.tstart = ceil(ops.trange(1) * ops.fs); 
-ops.tend   = min(nTimepoints, ceil(ops.trange(2) * ops.fs)); 
-ops.sampsToRead = ops.tend-ops.tstart; 
+bytes = get_file_size(ops.fbinary);
+nTimepoints = floor(bytes/NchanTOT/2);
+ops.tstart = ceil(ops.trange(1) * ops.fs);
+ops.tend   = min(nTimepoints, ceil(ops.trange(2) * ops.fs));
+ops.sampsToRead = ops.tend-ops.tstart;
 ops.twind = ops.tstart * NchanTOT*2;
 
 Nbatch      = ceil(ops.sampsToRead /(NT-ops.ntbuff));

--- a/utils/get_file_size.m
+++ b/utils/get_file_size.m
@@ -1,0 +1,16 @@
+function bytes = get_file_size(fname)
+% gets file size ensuring that symlinks are dereferenced
+    bytes = NaN;
+    if isunix
+        cmd = sprintf('stat -Lc %%s %s', fname);
+        [status, r] = system(cmd);
+        if status == 0
+            bytes = str2double(r);
+        end
+    end
+
+    if isnan(bytes)
+        o = dir(fname);
+        bytes = o.bytes;
+    end
+end


### PR DESCRIPTION
Matlab's dir command returns the number of bytes of the symlink itself rather than the link target. If a raw data file is processed by Kilosort2 via a symlink, `get_file_size` returns the correct file size by using the `stat` command. On Windows, dir continues to be used (I'm not sure what happens if someone on Windows uses mklink).