### PR TITLE
Fixing mexCUDA warnings int -> unsigned int

### DIFF
--- a/CUDA/mexClustering2.cu
+++ b/CUDA/mexClustering2.cu
@@ -248,7 +248,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 {
     /* Declare input variables*/
   double *Params, *d_Params;
-  int Nchan, NrankPC, Nspikes, Nfilters, NchanNear;
+  unsigned int Nchan, NrankPC, Nspikes, Nfilters, NchanNear;
 
   
   /* Initialize the MathWorks GPU API. */
@@ -256,11 +256,11 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
   /* read Params and copy to GPU */
   Params                = (double*) mxGetData(prhs[0]);
-  Nspikes               = (int) Params[0];  
-  Nfilters              = (int) Params[2];  
-  NrankPC             = (int) Params[1];  
-  NchanNear             = (int) Params[6];
-  Nchan                 = (int) Params[7];
+  Nspikes               = (unsigned int) Params[0];  
+  Nfilters              = (unsigned int) Params[2];  
+  NrankPC             = (unsigned int) Params[1];  
+  NchanNear             = (unsigned int) Params[6];
+  Nchan                 = (unsigned int) Params[7];
   
   // copy Params to GPU
   cudaMalloc(&d_Params,      sizeof(double)*mxGetNumberOfElements(prhs[0]));

--- a/CUDA/mexDistances2.cu
+++ b/CUDA/mexDistances2.cu
@@ -101,7 +101,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
 {
     /* Declare input variables*/
   double *Params, *d_Params;
-  int  Nspikes, Nfilters;
+  unsigned int  Nspikes, Nfilters;
   
   /* Initialize the MathWorks GPU API. */
   mxInitGPU();

--- a/CUDA/mexFilterPCs.cu
+++ b/CUDA/mexFilterPCs.cu
@@ -75,15 +75,15 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
   /* Declare input variables*/
   double *Params, *d_Params;
-  int NT, Nchan;
+  unsigned int NT, Nchan;
 
   
   /* read Params and copy to GPU */
   // NT, Nchan, nt0, Nrank
   
   Params  	= (double*) mxGetData(prhs[0]);
-  NT		= (int) Params[0];
-  Nchan     = (int) Params[1];
+  NT		= (unsigned int) Params[0];
+  Nchan     = (unsigned int) Params[1];
         
   cudaMalloc(&d_Params,      sizeof(double)*mxGetNumberOfElements(prhs[0]));
   cudaMemcpy(d_Params,Params,sizeof(double)*mxGetNumberOfElements(prhs[0]),cudaMemcpyHostToDevice);

--- a/CUDA/mexGetSpikes2.cu
+++ b/CUDA/mexGetSpikes2.cu
@@ -246,9 +246,9 @@ __global__ void extract_snips(const double *Params, const int *st, const int *id
 __global__ void extract_snips2(const double *Params, const float *err, const int *st, const int *id,
         const int *counter, const int *kk, const int *iC, const float *W, float *WU){
     
-  int nt0, tidx, tidy, bid, ind, icl, NT, Nchan, Nmax, Nsum, NchanNear;
+  int nt0, tidx, tidy, bid, ind, icl, Nchan, Nmax, Nsum, NchanNear;
   
-  NT        = (int) Params[0];
+  //NT        = (int) Params[0];
   nt0       = (int) Params[4];
   Nchan     = (int) Params[9];
   Nsum      = (int) Params[13];
@@ -285,15 +285,15 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
   /* Declare input variables*/
   double *Params, *d_Params;
-  int nt0, NT, Nchan, Nnearest, Nrank;
+  unsigned int nt0, NT, Nchan, Nnearest, Nrank;
   
   /* read Params and copy to GPU */
   Params  	= (double*) mxGetData(prhs[0]);
-  NT		= (int) Params[0];
-  Nchan     = (int) Params[9];
-  nt0       = (int) Params[4];
-  Nnearest  = (int) Params[5];
-  Nrank     = (int) Params[14];
+  NT		= (unsigned int) Params[0];
+  Nchan     = (unsigned int) Params[9];
+  nt0       = (unsigned int) Params[4];
+  Nnearest  = (unsigned int) Params[5];
+  Nrank     = (unsigned int) Params[14];
   
   dim3 tpB(8, 2*nt0-1), tpF(16, Nnearest), tpS(nt0, 16);
         
@@ -347,8 +347,8 @@ void mexFunction(int nlhs, mxArray *plhs[],
   cudaMemset(d_st1,     0, maxFR *   sizeof(int));
   cudaMemset(d_id1,     0, maxFR *   sizeof(int));
     
-  int *counter;
-  counter = (int*) calloc(1,sizeof(int));
+  unsigned int *counter;
+  counter = (unsigned int*) calloc(1,sizeof(unsigned int));
   
   // filter the data with the temporal templates
   Conv1D<<<Nchan, Nthreads>>>(d_Params, d_data, d_W, d_dfilt);

--- a/CUDA/mexMPnu8.cu
+++ b/CUDA/mexMPnu8.cu
@@ -276,7 +276,7 @@ __global__ void	cleanup_spikes(const double *Params, const float *data,
   int lockout, indx, tid, bid, NT, tid0,  j, id0, t0;
   volatile __shared__ float sdata[Nthreads+2*81+1];
   bool flag=0;
-  float err0, Th, lam;
+  float err0, Th;
   
   lockout   = (int) Params[4] - 1;
   tid 		= threadIdx.x;
@@ -285,7 +285,7 @@ __global__ void	cleanup_spikes(const double *Params, const float *data,
   NT      	=   (int) Params[0];
   tid0 		= bid * blockDim.x ;
   Th 		= (float) Params[2];
-  lam 	    = (float) Params[7];
+  //lam 	    = (float) Params[7];
   
   while(tid0<NT-Nthreads-lockout+1){
       if (tid<2*lockout)
@@ -558,18 +558,18 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
   /* Declare input variables*/
   double *Params, *d_Params;
-  int nt0, Nchan, NT, Nfilt, Nnearest, Nrank, NchanU;
+  unsigned int nt0, Nchan, NT, Nfilt, Nnearest, Nrank, NchanU;
 
   
   /* read Params and copy to GPU */
   Params  	= (double*) mxGetData(prhs[0]);
-  NT		= (int) Params[0];
-  Nfilt     = (int) Params[1];
-  nt0       = (int) Params[4];
-  Nnearest  = (int) Params[5];
-  Nrank     = (int) Params[6];
-  NchanU    = (int) Params[10];  
-  Nchan     = (int) Params[9];
+  NT		= (unsigned int) Params[0];
+  Nfilt     = (unsigned int) Params[1];
+  nt0       = (unsigned int) Params[4];
+  Nnearest  = (unsigned int) Params[5];
+  Nrank     = (unsigned int) Params[6];
+  NchanU    = (unsigned int) Params[10];  
+  Nchan     = (unsigned int) Params[9];
   
   cudaMalloc(&d_Params,      sizeof(double)*mxGetNumberOfElements(prhs[0]));
   cudaMemcpy(d_Params,Params,sizeof(double)*mxGetNumberOfElements(prhs[0]),cudaMemcpyHostToDevice);
@@ -727,7 +727,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
   
   float *x, *feat, *featPC, *vexp;
   int *st, *id;
-  int minSize;
+  unsigned int minSize;
   if (counter[0]<maxFR)  minSize = counter[0];
   else                   minSize = maxFR;
   const mwSize dimst[] 	= {minSize,1}; 

--- a/CUDA/mexSVDsmall2.cu
+++ b/CUDA/mexSVDsmall2.cu
@@ -285,14 +285,14 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
   /* Declare input variables*/
   double *Params, *d_Params;
-  int nt0, Nfilt, Nrank, Nchan;
+  unsigned int nt0, Nfilt, Nrank, Nchan;
 
   /* read Params and copy to GPU */
   Params  	= (double*) mxGetData(prhs[0]);
-  Nfilt     = (int) Params[1];
-  nt0       = (int) Params[4];
-  Nrank     = (int) Params[6];
-  Nchan     = (int) Params[9];
+  Nfilt     = (unsigned int) Params[1];
+  nt0       = (unsigned int) Params[4];
+  Nrank     = (unsigned int) Params[6];
+  Nchan     = (unsigned int) Params[9];
 
   cudaMalloc(&d_Params,      sizeof(double)*mxGetNumberOfElements(prhs[0]));
   cudaMemcpy(d_Params,Params,sizeof(double)*mxGetNumberOfElements(prhs[0]),cudaMemcpyHostToDevice);

--- a/CUDA/mexThSpkPC.cu
+++ b/CUDA/mexThSpkPC.cu
@@ -203,14 +203,14 @@ void mexFunction(int nlhs, mxArray *plhs[],
 
   /* Declare input variables*/
   double *Params, *d_Params;
-  int NT, Nchan, NchanNear, NrankPC;
+  unsigned int NT, Nchan, NchanNear, NrankPC;
   
   /* read Params and copy to GPU */
   Params  	= (double*) mxGetData(prhs[0]);
-  NT 		= (int) Params[0];
-  Nchan     = (int) Params[1];  
-  NchanNear = (int) Params[2];      
-  NrankPC     = (int) Params[6];
+  NT 		= (unsigned int) Params[0];
+  Nchan     = (unsigned int) Params[1];  
+  NchanNear = (unsigned int) Params[2];      
+  NrankPC     = (unsigned int) Params[6];
         
   cudaMalloc(&d_Params,      sizeof(double)*mxGetNumberOfElements(prhs[0]));
   cudaMemcpy(d_Params,Params,sizeof(double)*mxGetNumberOfElements(prhs[0]),cudaMemcpyHostToDevice);
@@ -261,7 +261,7 @@ void mexFunction(int nlhs, mxArray *plhs[],
   cudaMemcpy(counter,     d_counter, sizeof(int), cudaMemcpyDeviceToHost);
   
   // move d_x to the CPU
-  int minSize=1;
+  unsigned int minSize=1;
   minSize = min(maxFR, counter[0]);
 
   const mwSize ddF[] 	= {NrankPC * NchanNear, minSize};

--- a/CUDA/mexWtW2.cu
+++ b/CUDA/mexWtW2.cu
@@ -83,15 +83,15 @@ void mexFunction(int nlhs, mxArray *plhs[],
 {
     /* Declare input variables*/
   double *Params, *d_Params;
-  int nt0, Nfilt;
+  unsigned int nt0, Nfilt;
 
   /* Initialize the MathWorks GPU API. */
   mxInitGPU();
 
   /* read Params and copy to GPU */
   Params  	= (double*) mxGetData(prhs[0]);
-  Nfilt		= (int) Params[1];
-  nt0       = (int) Params[9];
+  Nfilt		= (unsigned int) Params[1];
+  nt0       = (unsigned int) Params[9];
   
   cudaMalloc(&d_Params,      sizeof(double)*mxGetNumberOfElements(prhs[0]));
   cudaMemcpy(d_Params,Params,sizeof(double)*mxGetNumberOfElements(prhs[0]),cudaMemcpyHostToDevice);


### PR DESCRIPTION
Cosmetic changes to the mexcuda files to avoid the warnings about
downsizing from int to mwSize (unsigned long int). Obviously doesn't
change anything important but might be helpful for people having issues
if the screen isn't cluttered with warnings.