### PR TITLE
Fix variable name

### DIFF
--- a/preProcess/preprocessDataSub.m
+++ b/preProcess/preprocessDataSub.m
@@ -113,7 +113,7 @@ for ibatch = 1:Nbatch
     
     % CAR, common average referencing by median
     if getOr(ops, 'CAR', 1)
-        datr = datr - median(datr, 2);
+        dataRAW = dataRAW - median(dataRAW, 2);
     end
     
     datr = filter(b1, a1, dataRAW);


### PR DESCRIPTION
after moving CAR filter before bandpass filtering in #103, 'datr' should be renamed as dataRAW. 'datr' only exists after bandpass filtering