### PR TITLE
KCoords is not passed through GUI

### DIFF
--- a/gui/ksGUI.m
+++ b/gui/ksGUI.m
@@ -656,7 +656,10 @@ classdef ksGUI < handle
             conn = obj.P.chanMap.connected;
             chanMap.chanMap = obj.P.chanMap.chanMap(conn); 
             chanMap.xcoords = obj.P.chanMap.xcoords(conn); 
-            chanMap.ycoords = obj.P.chanMap.ycoords(conn); 
+            chanMap.ycoords = obj.P.chanMap.ycoords(conn);
+            if isfield(obj.P.chanMap, 'kcoords')
+                chanMap.kcoords = obj.P.chanMap.kcoords(conn);
+            end
             obj.ops.chanMap = chanMap;
             
             % sanitize options set in the gui


### PR DESCRIPTION
Hello,

I tried to use my custom channel map and to launch Kilosort2 pipeline execution via Gui. I was surprised to see that instead of 8 shanks, 8 channels each, that I defined via kcoords variable, I see 32 linear probe configuration after Kilosort2 finishes calculation.

This comes from the fact that in ksGui, kcoords are not loaded from the channel map. That would mean that when preprocessDataSub.m will use loadChanMap.m, kcoords from default 32-channel linear probe will be used.

I suggest to load kcoords on the level of ksGUI, if kcoords exists.

Thanks!