### PR TITLE
Experimental Python port of Kilosort 2

### DIFF
--- a/pykilosort/__init__.py
+++ b/pykilosort/__init__.py
@@ -1,0 +1,40 @@
+import logging
+import os.path as op
+
+from .utils import Bunch, memmap_binary_file, read_data, load_probe  # noqa
+from .main import run  # noqa
+
+
+__version__ = '2.0.0a0'
+
+
+# Set a null handler on the root logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+_logger_fmt = '%(asctime)s.%(msecs)03d [%(levelname)s] %(caller)s %(message)s'
+_logger_date_fmt = '%H:%M:%S'
+
+
+class _Formatter(logging.Formatter):
+    def format(self, record):
+        # Only keep the first character in the level name.
+        record.levelname = record.levelname[0]
+        filename = op.splitext(op.basename(record.pathname))[0]
+        record.caller = '{:s}:{:d}'.format(filename, record.lineno).ljust(20)
+        message = super(_Formatter, self).format(record)
+        color_code = {'D': '90', 'I': '0', 'W': '33', 'E': '31'}.get(record.levelname, '7')
+        message = '\33[%sm%s\33[0m' % (color_code, message)
+        return message
+
+
+def add_default_handler(level='INFO', logger=logger, filename=None):
+    if filename is None:
+        handler = logging.StreamHandler()
+    else:
+        handler = logging.FileHandler(filename)
+    handler.setLevel(level)
+    formatter = _Formatter(fmt=_logger_fmt, datefmt=_logger_date_fmt)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/pykilosort/cluster.py
+++ b/pykilosort/cluster.py
@@ -1,0 +1,572 @@
+import logging
+from math import ceil
+
+import numpy as np
+import cupy as cp
+from tqdm import tqdm
+
+from .preprocess import my_min, my_sum
+from .cptools import svdecon, zscore, ones
+from .utils import Bunch, get_cuda
+
+logger = logging.getLogger(__name__)
+
+
+def getClosestChannels(probe, sigma, NchanClosest):
+    # this function outputs the closest channels to each channel,
+    # as well as a Gaussian-decaying mask as a function of pairwise distances
+    # sigma is the standard deviation of this Gaussian-mask
+
+    # compute distances between all pairs of channels
+    xc = cp.asarray(probe.xc, dtype=np.float32, order='F')
+    yc = cp.asarray(probe.yc, dtype=np.float32, order='F')
+    C2C = (xc[:, np.newaxis] - xc) ** 2 + (yc[:, np.newaxis] - yc) ** 2
+    C2C = cp.sqrt(C2C)
+    Nchan = C2C.shape[0]
+
+    # sort distances
+    isort = cp.argsort(C2C, axis=0)
+
+    # take NchanCLosest neighbors for each primary channel
+    iC = isort[:NchanClosest, :]
+
+    # in some cases we want a mask that decays as a function of distance between pairs of channels
+    # this is an awkward indexing to get the corresponding distances
+    ix = iC + cp.arange(0, Nchan ** 2, Nchan)
+    mask = cp.exp(-C2C.T.ravel()[ix] ** 2 / (2 * sigma ** 2))
+
+    # masks should be unit norm for each channel
+    mask = mask / cp.sqrt(1e-3 + cp.sum(mask ** 2, axis=0))
+
+    return iC, mask, C2C
+
+
+def isolated_peaks_new(S1, params):
+    """
+    takes a matrix of timepoints by channels S1
+    outputs threshold crossings that are relatively isolated from other peaks
+    outputs row, column and magnitude of the threshold crossing
+    """
+    S1 = cp.asarray(S1)
+
+    # finding the local minimum in a sliding window within plus/minus loc_range extent
+    # across time and across channels
+    smin = my_min(S1, params.loc_range, [0, 1])
+
+    # the peaks are samples that achieve this local minimum, AND have negativities less
+    # than a preset threshold
+    peaks = (S1 < smin + 1e-3) & (S1 < params.spkTh)
+
+    # only take local peaks that are isolated from other local peaks
+    # if there is another local peak close by, this sum will be at least 2
+    sum_peaks = my_sum(peaks, params.long_range, [0, 1])
+    # set to 0 peaks that are not isolated, and multiply with the voltage values
+    peaks = peaks * (sum_peaks < 1.2) * S1
+
+    # exclude temporal buffers
+    peaks[:params.nt0, :] = 0
+    peaks[-params.nt0:, :] = 0
+
+    # find the non-zero peaks, and take their amplitudes
+    col, row = cp.nonzero(peaks.T)
+    # invert the sign of the amplitudes
+    mu = -peaks[row, col]
+
+    return row, col, mu
+
+
+def get_SpikeSample(dataRAW, row, col, params):
+    """
+    given a batch of data (time by channels), and some time (row) and channel (col) indices for
+    spikes, this function returns the 1D time clips of voltage around those spike times
+    """
+    nT, nChan = dataRAW.shape
+
+    # times around the peak to consider
+    dt = cp.arange(params.nt0)
+
+    # the negativity is expected at nt0min, so we align the detected peaks there
+    dt = -params.nt0min + dt
+
+    # temporal indices (awkward way to index into full matrix of data)
+    indsT = row + dt[:, np.newaxis] + 1  # broadcasting
+    indsC = col
+
+    indsC[indsC < 0] = 0  # anything that's out of bounds just gets set to the limit
+    indsC[indsC >= nChan] = nChan - 1  # only needed for channels not time (due to time buffer)
+
+    indsT = cp.transpose(cp.atleast_3d(indsT), [0, 2, 1])
+    indsC = cp.transpose(cp.atleast_3d(indsC), [2, 0, 1])
+
+    # believe it or not, these indices grab just the right timesamples forour spikes
+    ix = indsT + indsC * nT
+
+    # grab the data and reshape it appropriately (time samples  by channels by num spikes)
+    clips = dataRAW.T.ravel()[ix[:, 0, :]].reshape((dt.size, row.size), order='F')  # HERE
+    return clips
+
+
+def extractPCfromSnippets(proc, probe=None, params=None, Nbatch=None):
+    # extracts principal components for 1D snippets of spikes from all channels
+    # loads a subset of batches to find these snippets
+
+    NT = params.NT
+    nPCs = params.nPCs
+    Nchan = probe.Nchan
+
+    batchstart = np.arange(0, NT * Nbatch + 1, NT).astype(np.int64)
+
+    # extract the PCA projections
+    # initialize the covariance of single-channel spike waveforms
+    CC = cp.zeros(params.nt0, dtype=np.float32)
+
+    # from every 100th batch
+    for ibatch in range(0, Nbatch, 100):
+        offset = Nchan * batchstart[ibatch]
+        dat = proc.flat[offset:offset + NT * Nchan].reshape((-1, Nchan), order='F')
+        if dat.shape[0] == 0:
+            continue
+
+        # move data to GPU and scale it back to unit variance
+        dataRAW = cp.asarray(dat, dtype=np.float32) / params.scaleproc
+
+        # find isolated spikes from each batch
+        row, col, mu = isolated_peaks_new(dataRAW, params)
+
+        # for each peak, get the voltage snippet from that channel
+        c = get_SpikeSample(dataRAW, row, col, params)
+
+        # scale covariance down by 1,000 to maintain a good dynamic range
+        CC = CC + cp.dot(c, c.T) / 1e3
+
+    # the singular vectors of the covariance matrix are the PCs of the waveforms
+    U, Sv, V = svdecon(CC)
+
+    wPCA = U[:, :nPCs]  # take as many as needed
+
+    # adjust the arbitrary sign of the first PC so its negativity is downward
+    wPCA[:, 0] = -wPCA[:, 0] * cp.sign(wPCA[20, 0])
+
+    return wPCA
+
+
+def sortBatches2(ccb0):
+    # takes as input a matrix of nBatches by nBatches containing
+    # dissimilarities.
+    # outputs a matrix of sorted batches, and the sorting order, such that
+    # ccb1 = ccb0(isort, isort)
+
+    # put this matrix on the GPU
+    ccb0 = cp.asarray(ccb0, order='F')
+
+    # compute its svd on the GPU (this might also be fast enough on CPU)
+    u, s, v = svdecon(ccb0)
+    # HACK: consistency with MATLAB
+    u = u * cp.sign(u[0, 0])
+    v = v * cp.sign(u[0, 0])
+
+    # initialize the positions xs of the batch embeddings to be very small but proportional to
+    # the first PC
+    xs = .01 * u[:, 0] / cp.std(u[:, 0], ddof=1)
+
+    # 200 iterations of gradient descent should be enough
+    niB = 200
+
+    # this learning rate should usually work fine, since it scales with the average gradient
+    # and ccb0 is z-scored
+    eta = 1
+    for k in tqdm(range(niB), desc="Sorting %d batches" % ccb0.shape[0]):
+        # euclidian distances between 1D embedding positions
+        ds = (xs - xs[:, np.newaxis]) ** 2
+        # the transformed distances go through this function
+        W = cp.log(1 + ds)
+
+        # the error is the difference between ccb0 and W
+        err = ccb0 - W
+
+        # ignore the mean value of ccb0
+        err = err - cp.mean(err, axis=0)
+
+        # backpropagate the gradients
+        err = err / (1 + ds)
+        err2 = err * (xs[:, np.newaxis] - xs)
+        D = cp.mean(err2, axis=1)  # one half of the gradients is along this direction
+        E = cp.mean(err2, axis=0)  # the other half is along this direction
+        # we don't need to worry about the gradients for the diagonal because those are 0
+
+        # final gradients for the embedding variable
+        dx = -D + E.T
+
+        # take a gradient step
+        xs = xs - eta * dx
+
+    # sort the embedding positions xs
+    isort = cp.argsort(xs, axis=0)
+
+    # sort the matrix of dissimilarities
+    ccb1 = ccb0[isort, :][:, isort]
+
+    return ccb1, isort
+
+
+def initializeWdata2(call, uprojDAT, Nchan, nPCs, Nfilt, iC):
+    # this function initializes cluster means for the fast kmeans per batch
+    # call are time indices for the spikes
+    # uprojDAT are features projections (Nfeatures by Nspikes)
+    # some more parameters need to be passed in from the main workspace
+
+    # pick random spikes from the sample
+    # WARNING: replace ceil by warning because this is a random index, and 0/1 indexing
+    # discrepancy between Python and MATLAB.
+    irand = np.floor(np.random.rand(Nfilt) * uprojDAT.shape[1]).astype(np.int32)
+
+    W = cp.zeros((nPCs, Nchan, Nfilt), dtype=np.float32)
+
+    for t in range(Nfilt):
+        ich = iC[:, call[irand[t]]]  # the channels on which this spike lives
+        # for each selected spike, get its features
+        W[:, ich, t] = uprojDAT[:, irand[t]].reshape(W[:, ich, t].shape, order='F')
+
+    W = W.reshape((-1, Nfilt), order='F')  # HERE
+    # add small amount of noise in case we accidentally picked the same spike twice
+    W = W + .001 * cp.random.normal(size=W.shape).astype(np.float32)
+    mu = cp.sqrt(cp.sum(W ** 2, axis=0))  # get the mean of the template
+    W = W / (1e-5 + mu)  # and normalize the template
+    W = W.reshape((nPCs, Nchan, Nfilt), order='F')  # HERE
+    nW = (W[0, ...] ** 2)  # squared amplitude of the first PC feture
+    W = W.reshape((nPCs * Nchan, Nfilt), order='F')  # HERE
+    # determine biggest channel according to the amplitude of the first PC
+    Wheights = cp.argmax(nW, axis=0)
+
+    return W, mu, Wheights, irand
+
+
+def mexThSpkPC(Params, dataRAW, wPCA, iC):
+    code, constants = get_cuda('mexThSpkPC')
+    Nthreads = constants.Nthreads
+    maxFR = constants.maxFR
+
+    NT, Nchan, NchanNear, nt0, nt0min, spkTh, NrankPC = Params
+    NT = int(NT)
+    Nchan = int(Nchan)
+
+    # Input GPU arrays.
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+    d_data = cp.asarray(dataRAW, dtype=np.float32, order='F')
+    d_W = cp.asarray(wPCA, dtype=np.float32, order='F')
+    d_iC = cp.asarray(iC, dtype=np.int32, order='F')
+
+    # New GPU arrays.
+    d_dout = cp.zeros((Nchan, NT), dtype=np.float32, order='F')
+    d_dmax = cp.zeros((Nchan, NT), dtype=np.float32, order='F')
+    d_st = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_id = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_counter = cp.zeros(1, dtype=np.int32, order='F')
+
+    # filter the data with the temporal templates
+    Conv1D = cp.RawKernel(code, 'Conv1D')
+    Conv1D((Nchan,), (Nthreads,), (d_Params, d_data, d_W, d_dout))
+
+    # get the max of the data
+    max1D = cp.RawKernel(code, 'max1D')
+    max1D((Nchan,), (Nthreads,), (d_Params, d_dout, d_dmax))
+
+    # take max across nearby channels
+    maxChannels = cp.RawKernel(code, 'maxChannels')
+    maxChannels(
+        (int(NT // Nthreads),), (Nthreads,),
+        (d_Params, d_dout, d_dmax, d_iC, d_st, d_id, d_counter))
+
+    # move d_x to the CPU
+    minSize = 1
+    minSize = min(maxFR, int(d_counter[0]))
+
+    d_featPC = cp.zeros((NrankPC * NchanNear, minSize), dtype=np.float32, order='F')
+
+    d_id2 = cp.zeros(minSize, dtype=np.int32, order='F')
+
+    if (minSize > 0):
+        computeProjections = cp.RawKernel(code, 'computeProjections')
+        computeProjections(
+            (minSize,), (NchanNear, NrankPC), (d_Params, d_data, d_iC, d_st, d_id, d_W, d_featPC))
+
+    # TODO: check that the copy occurs on the GPU only
+    d_id2[:] = d_id[:minSize]
+
+    # Free memory.
+    del d_st, d_id, d_counter, d_Params, d_dmax, d_dout
+    # free_gpu_memory()
+
+    return d_featPC, d_id2
+
+
+def extractPCbatch2(proc, params, probe, wPCA, ibatch, iC, Nbatch):
+    # this function finds threshold crossings in the data using
+    # projections onto the pre-determined principal components
+    # wPCA is number of time samples by number of PCs
+    # ibatch is a scalar indicating which batch to analyze
+    # iC is NchanNear by Nchan, indicating for each channel the nearest
+    # channels to it
+
+    nt0min = params.nt0min
+    spkTh = params.ThPre
+    nt0, NrankPC = wPCA.shape
+    NT, Nchan = params.NT, probe.Nchan
+
+    # starts with predefined PCA waveforms
+    wPCA = wPCA[:, :3]
+
+    NchanNear = iC.shape[0]
+
+    # batches start at these timepoints
+    batchstart = np.arange(0, NT * Nbatch + 1, NT).astype(np.int64)
+
+    offset = Nchan * batchstart[ibatch]
+    dat = proc.flat[offset:offset + NT * Nchan].reshape((-1, Nchan), order='F')
+    dataRAW = cp.asarray(dat, dtype=np.float32) / params.scaleproc
+
+    # another Params variable to take all our parameters into the C++ code
+    Params = [NT, Nchan, NchanNear, nt0, nt0min, spkTh, NrankPC]
+
+    # call a CUDA function to do the hard work
+    # returns a matrix of features uS, as well as the center channels for each spike
+    uS, idchan = mexThSpkPC(Params, dataRAW, wPCA, iC)
+
+    return uS, idchan
+
+
+def mexClustering2(Params, uproj, W, mu, call, iMatch, iC):
+
+    code, _ = get_cuda('mexClustering2')
+
+    Nspikes = int(Params[0])
+    NrankPC = int(Params[1])
+    Nfilters = int(Params[2])
+    NchanNear = int(Params[6])
+    Nchan = int(Params[7])
+
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+    d_uproj = cp.asarray(uproj, dtype=np.float32, order='F')
+    d_W = cp.asarray(W, dtype=np.float32, order='F')
+    d_mu = cp.asarray(mu, dtype=np.float32, order='F')
+    d_call = cp.asarray(call, dtype=np.int32, order='F')
+    d_iC = cp.asarray(iC, dtype=np.int32, order='F')
+    d_iMatch = cp.asarray(iMatch, dtype=np.bool, order='F')
+
+    d_dWU = cp.zeros((NrankPC * Nchan, Nfilters), dtype=np.float32, order='F')
+    d_cmax = cp.zeros((Nspikes, Nfilters), dtype=np.float32, order='F')
+    d_id = cp.zeros(Nspikes, dtype=np.int32, order='F')
+    d_x = cp.zeros(Nspikes, dtype=np.float32, order='F')
+    d_nsp = cp.zeros(Nfilters, dtype=np.int32, order='F')
+    d_V = cp.zeros(Nfilters, dtype=np.float32, order='F')
+
+    # get list of cmaxes for each combination of neuron and filter
+    computeCost = cp.RawKernel(code, 'computeCost')
+    computeCost(
+        (Nfilters,), (1024,), (d_Params, d_uproj, d_mu, d_W, d_iMatch, d_iC, d_call, d_cmax))
+
+    # loop through cmax to find best template
+    bestFilter = cp.RawKernel(code, 'bestFilter')
+    bestFilter((40,), (256,), (d_Params, d_iMatch, d_iC, d_call, d_cmax, d_id, d_x))
+
+    # average all spikes for same template -- ORIGINAL
+    average_snips = cp.RawKernel(code, 'average_snips')
+    average_snips(
+        (Nfilters,), (NrankPC, NchanNear), (d_Params, d_iC, d_call, d_id, d_uproj, d_cmax, d_dWU))
+
+    count_spikes = cp.RawKernel(code, 'count_spikes')
+    count_spikes((7,), (256,), (d_Params, d_id, d_nsp, d_x, d_V))
+
+    del d_Params, d_V
+
+    return d_dWU, d_id, d_x, d_nsp, d_cmax
+
+
+def mexDistances2(Params, Ws, W, iMatch, iC, Wh, mus, mu):
+    code, _ = get_cuda('mexDistances2')
+
+    Nspikes = int(Params[0])
+    Nfilters = int(Params[2])
+
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+
+    d_Ws = cp.asarray(Ws, dtype=np.float32, order='F')
+    d_W = cp.asarray(W, dtype=np.float32, order='F')
+    d_iMatch = cp.asarray(iMatch, dtype=np.bool, order='F')
+    d_iC = cp.asarray(iC, dtype=np.int32, order='F')
+    d_Wh = cp.asarray(Wh, dtype=np.int32, order='F')
+    d_mu = cp.asarray(mu, dtype=np.float32, order='F')
+    d_mus = cp.asarray(mus, dtype=np.float32, order='F')
+
+    d_cmax = cp.zeros(Nspikes * Nfilters, dtype=np.float32, order='F')
+    d_id = cp.zeros(Nspikes, dtype=np.int32, order='F')
+    d_x = cp.zeros(Nspikes, dtype=np.float32, order='F')
+
+    # get list of cmaxes for each combination of neuron and filter
+    computeCost = cp.RawKernel(code, 'computeCost')
+    computeCost(
+        (Nfilters,), (1024,), (d_Params, d_Ws, d_mus, d_W, d_mu, d_iMatch, d_iC, d_Wh, d_cmax))
+
+    # loop through cmax to find best template
+    bestFilter = cp.RawKernel(code, 'bestFilter')
+    bestFilter((40,), (256,), (d_Params, d_iMatch, d_Wh, d_cmax, d_mus, d_id, d_x))
+
+    del d_Params, d_cmax
+
+    return d_id, d_x
+
+
+def clusterSingleBatches(ctx):
+    """
+    outputs an ordering of the batches according to drift
+    for each batch, it extracts spikes as threshold crossings and clusters them with kmeans
+    the resulting cluster means are then compared for all pairs of batches, and a dissimilarity
+    score is assigned to each pair
+    the matrix of similarity scores is then re-ordered so that low dissimilaity is along
+    the diagonal
+    """
+    Nbatch = ctx.intermediate.Nbatch
+    params = ctx.params
+    probe = ctx.probe
+    raw_data = ctx.raw_data
+    ir = ctx.intermediate
+    proc = ir.proc
+
+    if not params.reorder:
+        # if reordering is turned off, return consecutive order
+        iorig = np.arange(Nbatch)
+        return iorig, None, None
+
+    nPCs = params.nPCs
+    Nfilt = ceil(probe.Nchan / 2)
+
+    # extract PCA waveforms pooled over channels
+    wPCA = extractPCfromSnippets(proc, probe=probe, params=params, Nbatch=Nbatch)
+
+    Nchan = probe.Nchan
+    niter = 10  # iterations for k-means. we won't run it to convergence to save time
+
+    nBatches = Nbatch
+    NchanNear = min(Nchan, 2 * 8 + 1)
+
+    # initialize big arrays on the GPU to hold the results from each batch
+    # this holds the unit norm templates
+    Ws = cp.zeros((nPCs, NchanNear, Nfilt, nBatches), dtype=np.float32, order='F')
+    # this holds the scalings
+    mus = cp.zeros((Nfilt, nBatches), dtype=np.float32, order='F')
+    # this holds the number of spikes for that cluster
+    ns = cp.zeros((Nfilt, nBatches), dtype=np.float32, order='F')
+    # this holds the center channel for each template
+    Whs = ones((Nfilt, nBatches), dtype=np.int32, order='F')
+
+    i0 = 0
+    NrankPC = 3  # I am not sure if this gets used, but it goes into the function
+
+    # return an array of closest channels for each channel
+    iC = getClosestChannels(probe, params.sigmaMask, NchanNear)[0]
+
+    for ibatch in tqdm(range(nBatches), desc="Clustering spikes"):
+
+        # extract spikes using PCA waveforms
+        uproj, call = extractPCbatch2(
+            proc, params, probe, wPCA, min(nBatches - 2, ibatch), iC, Nbatch)
+
+        if cp.sum(cp.isnan(uproj)) > 0:
+            break  # I am not sure what case this safeguards against....
+
+        if uproj.shape[1] > Nfilt:
+
+            # this initialize the k-means
+            W, mu, Wheights, irand = initializeWdata2(call, uproj, Nchan, nPCs, Nfilt, iC)
+
+            # Params is a whole bunch of parameters sent to the C++ scripts inside a float64 vector
+            Params = [uproj.shape[1], NrankPC, Nfilt, 0, W.shape[0], 0, NchanNear, Nchan]
+
+            for i in range(niter):
+
+                Wheights = Wheights.reshape((1, 1, -1), order='F')
+                iC = cp.atleast_3d(iC)
+
+                # we only compute distances to clusters on the same channels
+                # this tells us which spikes and which clusters might match
+                iMatch = cp.min(cp.abs(iC - Wheights), axis=0) < .1
+
+                # get iclust and update W
+                # CUDA script to efficiently compute distances for pairs in which iMatch is 1
+                dWU, iclust, dx, nsp, dV = mexClustering2(Params, uproj, W, mu, call, iMatch, iC)
+
+                dWU = dWU / (1e-5 + nsp.T)  # divide the cumulative waveform by the number of spike
+
+                mu = cp.sqrt(cp.sum(dWU ** 2, axis=0))  # norm of cluster template
+                W = dWU / (1e-5 + mu)  # unit normalize templates
+
+                W = W.reshape((nPCs, Nchan, Nfilt), order='F')
+                nW = W[0, ...] ** 2  # compute best channel from the square of the first PC feature
+                W = W.reshape((Nchan * nPCs, Nfilt), order='F')
+
+                Wheights = cp.argmax(nW, axis=0)  # the new best channel of each cluster template
+
+            # carefully keep track of cluster templates in dense format
+            W = W.reshape((nPCs, Nchan, Nfilt), order='F')
+            W0 = cp.zeros((nPCs, NchanNear, Nfilt), dtype=np.float32, order='F')
+            for t in range(Nfilt):
+                W0[..., t] = W[:, iC[:, Wheights[t]], t].squeeze()
+            # I don't really know why this needs another normalization
+            W0 = W0 / (1e-5 + cp.sum(cp.sum(W0 ** 2, axis=0)[np.newaxis, ...], axis=1) ** .5)
+
+        # if a batch doesn't have enough spikes, it gets the cluster templates of the previous batc
+        if 'W0' in locals():
+            Ws[..., ibatch] = W0
+            mus[:, ibatch] = mu
+            ns[:, ibatch] = nsp
+            Whs[:, ibatch] = Wheights.astype(np.int32)
+        else:
+            logger.warning('Data batch #%d only had %d spikes.', ibatch, uproj.shape[1])
+
+        i0 = i0 + Nfilt
+
+    # anothr one of these Params variables transporting parameters to the C++ code
+    Params = [1, NrankPC, Nfilt, 0, W.shape[0], 0, NchanNear, Nchan]
+    # the total number of templates is the number of templates per batch times the number of batch
+    Params[0] = Ws.shape[2] * Ws.shape[3]
+
+    # initialize dissimilarity matrix
+    ccb = cp.zeros((nBatches, nBatches), dtype=np.float32, order='F')
+
+    for ibatch in tqdm(range(nBatches), desc="Computing distances"):
+        # for every batch, compute in parallel its dissimilarity to ALL other batches
+        Wh0 = Whs[:, ibatch]  # this one is the primary batch
+        W0 = Ws[..., ibatch]
+        mu = mus[..., ibatch]
+
+        # embed the templates from the primary batch back into a full, sparse representation
+        W = cp.zeros((nPCs, Nchan, Nfilt), dtype=np.float32, order='F')
+        for t in range(Nfilt):
+            W[:, iC[:, Wh0[t]], t] = cp.atleast_3d(Ws[:, :, t, ibatch])
+
+        # pairs of templates that live on the same channels are potential "matches"
+        iMatch = cp.min(cp.abs(iC - Wh0.reshape((1, 1, -1), order='F')), axis=0) < .1
+
+        # compute dissimilarities for iMatch = 1
+        iclust, ds = mexDistances2(Params, Ws, W, iMatch, iC, Whs, mus, mu)
+
+        # ds are squared Euclidian distances
+        ds = ds.reshape((Nfilt, -1), order='F')  # this should just be an Nfilt-long vector
+        ds = cp.maximum(0, ds)
+
+        # weigh the distances according to number of spikes in cluster
+        ccb[ibatch, :] = cp.mean(cp.sqrt(ds) * ns, axis=0) / cp.mean(ns, axis=0)
+
+    # ccb = cp.asnumpy(ccb)
+    # some normalization steps are needed: zscoring, and symmetrizing ccb
+    ccb0 = zscore(ccb, axis=0)
+    ccb0 = ccb0 + ccb0.T
+
+    # sort by manifold embedding algorithm
+    # iorig is the sorting of the batches
+    # ccbsort is the resorted matrix (useful for diagnosing drift)
+    ccbsort, iorig = sortBatches2(ccb0)
+
+    logger.info("Finished clustering.")
+
+    return Bunch(iorig=iorig, ccb0=ccb0, ccbsort=ccbsort)

--- a/pykilosort/cptools.py
+++ b/pykilosort/cptools.py
@@ -1,0 +1,402 @@
+from contextlib import redirect_stderr
+import ctypes
+import io
+from functools import wraps
+import logging
+from math import ceil
+from textwrap import dedent
+
+import numpy as np
+from scipy import signal as ss
+import cupy as cp
+
+logger = logging.getLogger(__name__)
+
+
+# LTI filter on GPU (NOTE: inefficient and soon to be deprecated)
+# ---------------------------------------------------------------
+
+def make_kernel(kernel, name, **const_arrs):
+    """Compile a kernel and pass optional constant ararys."""
+    mod = cp.core.core.compile_with_cache(kernel, prepend_cupy_headers=False)
+    b = cp.core.core.memory_module.BaseMemory()
+    # Pass constant arrays.
+    for n, arr in const_arrs.items():
+        b.ptr = mod.get_global_var(n)
+        p = cp.core.core.memory_module.MemoryPointer(b, 0)
+        p.copy_from_host(arr.ctypes.data_as(ctypes.c_void_p), arr.nbytes)
+    return mod.get_function(name)
+
+
+def get_lfilter_kernel(N, isfortran, reverse=False):
+    order = 'f' if isfortran else 'c'
+    return dedent("""
+    const int N = %d;
+    __constant__ float a[N + 1];
+    __constant__ float b[N + 1];
+
+
+    __device__ int get_idx_f(int n, int col, int n_samples, int n_channels) {
+        return n_samples * col + n;  // Fortran order.
+    }
+    __device__ int get_idx_c(int n, int col, int n_samples, int n_channels) {
+        return n * n_channels + col;  // C order.
+    }
+
+    // LTI IIR filter implemented using a difference equation.
+    // see https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.lfilter.html
+    extern "C" __global__ void lfilter(
+            const float* x, float* y, const int n_samples, const int n_channels){
+        // Initialize the state variables.
+        float d[N + 1];
+        for (int k = 0; k <= N; k++) {
+            d[k] = 0.0;
+        }
+
+        float xn = 0.0;
+        float yn = 0.0;
+
+        int idx = 0;
+
+        // Column index.
+        int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+
+        // IMPORTANT: avoid out of bounds memory accesses, which cause no errors but weird bugs.
+        if (col >= n_channels) return;
+
+        for (int n = 0; n < n_samples; n++) {
+            idx = get_idx_%s(%s, col, n_samples, n_channels);
+            // Load the input element.
+            xn = x[idx];
+            // Compute the output element.
+            yn = (b[0] * xn + d[0]) / a[0];
+            // Update the state variables.
+            for (int k = 0; k < N; k++) {
+                d[k] = b[k + 1] * xn - a[k + 1] * yn + d[k + 1];
+            }
+            // Update the output array.
+            y[idx] = yn;
+        }
+    }
+    """ % (N, order, 'n' if not reverse else 'n_samples - 1 - n'))
+
+
+def _get_lfilter_fun(b, a, is_fortran=True, axis=0, reverse=False):
+    assert axis == 0, "Only filtering along the first axis is currently supported."
+
+    b = np.atleast_1d(b).astype(np.float32)
+    a = np.atleast_1d(a).astype(np.float32)
+    N = max(len(b), len(a))
+    if len(b) < N:
+        b = np.pad(b, (0, (N - len(b))), mode='constant')
+    if len(a) < N:
+        a = np.pad(a, (0, (N - len(a))), mode='constant')
+    assert len(a) == len(b)
+    kernel = get_lfilter_kernel(N - 1, is_fortran, reverse=reverse)
+
+    lfilter = make_kernel(kernel, 'lfilter', b=b, a=a)
+
+    return lfilter
+
+
+def _apply_lfilter(lfilter_fun, arr):
+    assert isinstance(arr, cp.ndarray)
+    if arr.ndim == 1:
+        arr = arr[:, np.newaxis]
+    n_samples, n_channels = arr.shape
+
+    block = (min(128, n_channels),)
+    grid = (int(ceil(n_channels / float(block[0]))),)
+
+    arr = cp.asarray(arr, dtype=np.float32)
+    y = cp.zeros_like(arr, order='F' if arr.flags.f_contiguous else 'C', dtype=arr.dtype)
+
+    assert arr.dtype == np.float32
+    assert y.dtype == np.float32
+    assert arr.shape == y.shape
+
+    lfilter_fun(grid, block, (arr, y, int(y.shape[0]), int(y.shape[1])))
+    return y
+
+
+def lfilter(b, a, arr, axis=0, reverse=False):
+    """Perform a linear filter along the first axis on a GPU array."""
+    lfilter_fun = _get_lfilter_fun(
+        b, a, is_fortran=arr.flags.f_contiguous, axis=axis, reverse=reverse)
+    return _apply_lfilter(lfilter_fun, arr)
+
+
+# GPU FFT-based convolution
+# -------------------------
+
+def _clip(x, a, b):
+    return max(a, min(b, x))
+
+
+def pad(fcn_convolve):
+    @wraps(fcn_convolve)
+    def function_wrapper(x, b, axis=0, **kwargs):
+        # add the padding to the array
+        xsize = x.shape[axis]
+        if 'pad' in kwargs and kwargs['pad']:
+            npad = b.shape[axis] // 2
+            padd = cp.take(x, cp.arange(npad), axis=axis) * 0
+            if kwargs['pad'] == 'zeros':
+                x = cp.concatenate((padd, x, padd), axis=axis)
+            if kwargs['pad'] == 'constant':
+                x = cp.concatenate((padd * 0 + cp.mean(x[:npad]), x, padd + cp.mean(x[-npad:])),
+                                   axis=axis)
+            if kwargs['pad'] == 'flip':
+                pad_in = cp.flip(cp.take(x, cp.arange(1, npad + 1), axis=axis), axis=axis)
+                pad_out = cp.flip(cp.take(x, cp.arange(xsize - npad - 1, xsize - 1),
+                                          axis=axis), axis=axis)
+                x = cp.concatenate((pad_in, x, pad_out), axis=axis)
+        # run the convolution
+        y = fcn_convolve(x, b, **kwargs)
+        # remove padding from both arrays (necessary for x ?)
+        if 'pad' in kwargs and kwargs['pad']:
+            # remove the padding
+            y = cp.take(y, cp.arange(npad, x.shape[axis] - npad), axis=axis)
+            x = cp.take(x, cp.arange(npad, x.shape[axis] - npad), axis=axis)
+            assert xsize == x.shape[axis]
+            assert xsize == y.shape[axis]
+        return y
+    return function_wrapper
+
+
+def convolve_cpu(x, b):
+    """CPU convolution based on scipy.signal."""
+    x = np.asarray(x)
+    b = np.asarray(b)
+    if b.ndim == 1:
+        b = b[:, np.newaxis]
+    assert b.ndim == 2
+    y = ss.convolve(x, b, mode='same')
+    return y
+
+
+@pad
+def convolve_gpu_direct(x, b, **kwargs):
+    """Straight GPU FFT-based convolution that fits in memory."""
+    if not isinstance(x, cp.ndarray):
+        x = np.asarray(x)
+    if not isinstance(x, cp.ndarray):
+        b = np.asarray(b)
+    assert b.ndim == 1
+    n = x.shape[0]
+    xf = cp.fft.rfft(x, axis=0, n=n)
+    if xf.shape[0] > b.shape[0]:
+        bp = cp.pad(b, (0, n - b.shape[0]), mode='constant')
+        bp = cp.roll(bp, - b.size // 2 + 1)
+    else:
+        bp = b
+    bf = cp.fft.rfft(bp, n=n)[:, np.newaxis]
+    y = cp.fft.irfft(xf * bf, axis=0, n=n)
+    return y
+
+
+DEFAULT_CONV_CHUNK = 10_000
+
+
+@pad
+def convolve_gpu_chunked(x, b, pad='flip', nwin=DEFAULT_CONV_CHUNK, ntap=500, overlap=2000):
+    """Chunked GPU FFT-based convolution for large arrays.
+
+    This memory-controlled version splits the signal into chunks of n samples.
+    Each chunk is tapered in and out, the overlap is designed to get clear of the taper
+    splicing of overlaping chunks is done in a cosine way.
+
+    param: pad None, 'zeros', 'constant', 'flip'
+
+    """
+    x = cp.asarray(x)
+    b = cp.asarray(b)
+    assert b.ndim == 1
+    n = x.shape[0]
+    assert overlap >= 2 * ntap
+    # create variables, the gain is to control the splicing
+    y = cp.zeros_like(x)
+    gain = cp.zeros(n)
+    # compute tapers/constants outside of the loop
+    taper_in = (-cp.cos(cp.linspace(0, 1, ntap) * cp.pi) / 2 + 0.5)[:, cp.newaxis]
+    taper_out = cp.flipud(taper_in)
+    assert b.shape[0] < nwin < n
+    # this is the convolution wavelet that we shift to be 0 lag
+    bp = cp.pad(b, (0, nwin - b.shape[0]), mode='constant')
+    bp = cp.roll(bp, - b.size // 2 + 1)
+    bp = cp.fft.rfft(bp, n=nwin)[:, cp.newaxis]
+    # this is used to splice windows together: cosine taper. The reversed taper is complementary
+    scale = cp.minimum(cp.maximum(0, cp.linspace(-0.5, 1.5, overlap - 2 * ntap)), 1)
+    splice = (-cp.cos(scale * cp.pi) / 2 + 0.5)[:, cp.newaxis]
+    # loop over the signal by chunks and apply convolution in frequency domain
+    first = 0
+    while True:
+        first = min(n - nwin, first)
+        last = min(first + nwin, n)
+        # the convolution
+        x_ = cp.copy(x[first:last, :])
+        x_[:ntap] *= taper_in
+        x_[-ntap:] *= taper_out
+        x_ = cp.fft.irfft(cp.fft.rfft(x_, axis=0, n=nwin) * bp, axis=0, n=nwin)
+        # this is to check the gain of summing the windows
+        tt = cp.ones(nwin)
+        tt[:ntap] *= taper_in[:, 0]
+        tt[-ntap:] *= taper_out[:, 0]
+        # the full overlap is outside of the tapers: we apply a cosine splicing to this part only
+        if first > 0:
+            full_overlap_first = first + ntap
+            full_overlap_last = first + overlap - ntap
+            gain[full_overlap_first:full_overlap_last] *= (1. - splice[:, 0])
+            gain[full_overlap_first:full_overlap_last] += tt[ntap:overlap - ntap] * splice[:, 0]
+            gain[full_overlap_last:last] = tt[overlap - ntap:]
+            y[full_overlap_first:full_overlap_last] *= (1. - splice)
+            y[full_overlap_first:full_overlap_last] += x_[ntap:overlap - ntap] * splice
+            y[full_overlap_last:last] = x_[overlap - ntap:]
+        else:
+            y[first:last, :] = x_
+            gain[first:last] = tt
+        if last == n:
+            break
+        first += nwin - overlap
+    return y
+
+
+def convolve_gpu(x, b, **kwargs):
+    n = x.shape[0]
+    # Default chunk size : N samples along the first axis, the one to be chunked and over
+    # which to compute the convolution.
+    nwin = kwargs.get('nwin', DEFAULT_CONV_CHUNK)
+    assert nwin >= 0
+    if n <= nwin or nwin == 0:
+        return convolve_gpu_direct(x, b)
+    else:
+        nwin = max(nwin, b.shape[0] + 1)
+        return convolve_gpu_chunked(x, b, **kwargs)
+
+
+def svdecon(X, nPC0=None):
+    """
+    Input:
+    X : m x n matrix
+
+    Output:
+    X = U*S*V'
+
+    Description:
+
+    Does equivalent to svd(X,'econ') but faster
+
+        Vipin Vijayan (2014)
+
+    """
+
+    m, n = X.shape
+
+    nPC = nPC0 or min(m, n)
+
+    if m <= n:
+        C = cp.dot(X, X.T)
+        D, U = cp.linalg.eigh(C, 'U')
+
+        ix = cp.argsort(np.abs(D))[::-1]
+        d = D[ix]
+        U = U[:, ix]
+        d = d[:nPC]
+        U = U[:, :nPC]
+
+        V = cp.dot(X.T, U)
+        s = cp.sqrt(d)
+        V = V / s.T
+        S = cp.diag(s)
+    else:
+        C = cp.dot(X.T, X)
+        D, V = cp.linalg.eigh(C)
+
+        ix = cp.argsort(cp.abs(D))[::-1]
+        d = D[ix]
+        V = V[:, ix]
+
+        # convert evecs from X'*X to X*X'. the evals are the same.
+        U = cp.dot(X, V)
+        s = cp.sqrt(d)
+        U = U / s.T
+        S = cp.diag(s)
+
+    return U, S, V
+
+
+def svdecon_cpu(X):
+    U, S, V = np.linalg.svd(cp.asnumpy(X))
+    return U, np.diag(S), V
+
+
+def free_gpu_memory():
+    mempool = cp.get_default_memory_pool()
+    pinned_mempool = cp.get_default_pinned_memory_pool()
+    mempool.free_all_blocks()
+    pinned_mempool.free_all_blocks()
+
+
+# Work around CuPy bugs and limitations
+# -----------------------------------------------------------------------------
+
+def mean(x, axis=0):
+    if x.ndim == 1:
+        return cp.mean(x) if x.size else cp.nan
+    else:
+        s = list(x.shape)
+        del s[axis]
+        return (
+            cp.mean(x, axis=axis) if x.shape[axis] > 0
+            else cp.zeros(s, dtype=x.dtype, order='F'))
+
+
+def median(a, axis=0):
+    """Compute the median of a CuPy array on the GPU."""
+    a = cp.asarray(a)
+
+    if axis is None:
+        sz = a.size
+    else:
+        sz = a.shape[axis]
+    if sz % 2 == 0:
+        szh = sz // 2
+        kth = [szh - 1, szh]
+    else:
+        kth = [(sz - 1) // 2]
+
+    part = cp.partition(a, kth, axis=axis)
+
+    if part.shape == ():
+        # make 0-D arrays work
+        return part.item()
+    if axis is None:
+        axis = 0
+
+    indexer = [slice(None)] * part.ndim
+    index = part.shape[axis] // 2
+    if part.shape[axis] % 2 == 1:
+        # index with slice to allow mean (below) to work
+        indexer[axis] = slice(index, index + 1)
+    else:
+        indexer[axis] = slice(index - 1, index + 1)
+
+    return cp.mean(part[indexer], axis=axis)
+
+
+def var(x):
+    return cp.var(x, ddof=1) if x.size > 0 else cp.nan
+
+
+def ones(shape, dtype=None, order=None):
+    # HACK: cp.ones() has no order kwarg at the moment !
+    x = cp.zeros(shape, dtype=dtype, order=order)
+    x.fill(1)
+    return x
+
+
+def zscore(a, axis=0):
+    mns = a.mean(axis=axis)
+    sstd = a.std(axis=axis, ddof=0)
+    return (a - mns) / sstd

--- a/pykilosort/cuda/mexClustering2.cu
+++ b/pykilosort/cuda/mexClustering2.cu
@@ -1,0 +1,217 @@
+__global__ void computeCost(const double *Params, const float *uproj, const float *mu, const float *W,
+        const bool *match, const int *iC, const int *call, float *cmax){
+
+  int NrankPC,j, NchanNear, tid, bid, Nspikes, Nthreads, k, my_chan, this_chan, Nchan;
+  float xsum = 0.0f, Ci, lam;
+
+  Nspikes               = (int) Params[0];
+  NrankPC             = (int) Params[1];
+  Nthreads              = blockDim.x;
+  lam                   = (float) Params[5];
+  NchanNear             = (int) Params[6];
+  Nchan                 = (int) Params[7];
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  while(tid<Nspikes){
+      my_chan = call[tid];
+      if (match[my_chan + bid * Nchan]){
+          xsum = 0.0f;
+          for (k=0;k<NchanNear;k++)
+              for(j=0;j<NrankPC;j++){
+                  this_chan = iC[k + my_chan * NchanNear];
+                    xsum += uproj[j + NrankPC * k + NrankPC*NchanNear * tid] *
+                            W[j + NrankPC * this_chan +  NrankPC*Nchan * bid];
+              }
+          Ci = max(0.0f, xsum) + lam/mu[bid];
+
+          cmax[tid + bid*Nspikes] = Ci * Ci / (1.0f + lam/(mu[bid] * mu[bid])) - lam;
+      }
+      tid+= Nthreads;
+  }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void bestFilter(const double *Params,  const bool *match,
+        const int *iC, const int *call, const float *cmax, int *id, float *cx){
+
+  int Nchan, tid,tind,bid, ind, Nspikes, Nfilters, Nthreads, Nblocks, my_chan;
+  float max_running = 0.0f;
+
+  Nspikes               = (int) Params[0];
+  Nfilters              = (int) Params[2];
+  Nthreads              = blockDim.x;
+  Nblocks               = gridDim.x;
+  Nchan                = (int) Params[7];
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  tind = tid + bid * Nthreads;
+
+  while (tind<Nspikes){
+      max_running = 0.0f;
+      id[tind] = 0;
+      my_chan = call[tind];
+
+      for(ind=0; ind<Nfilters; ind++)
+          if (match[my_chan + ind * Nchan])
+              if (cmax[tind + ind*Nspikes] > max_running){
+                  id[tind] = ind;
+                  max_running = cmax[tind + ind*Nspikes];
+              }
+
+
+      cx[tind] = max_running;
+
+      tind += Nblocks*Nthreads;
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void average_snips(const double *Params, const int *iC, const int *call,
+        const int *id, const float *uproj, const float *cmax, float *WU){
+
+  int my_chan, this_chan, tidx, tidy, bid, ind, Nspikes, NrankPC, NchanNear, Nchan;
+  float xsum = 0.0f;
+
+  Nspikes               = (int) Params[0];
+  NrankPC             = (int) Params[1];
+  Nchan                = (int) Params[7];
+  NchanNear             = (int) Params[6];
+
+  tidx 		= threadIdx.x;
+  tidy 		= threadIdx.y;
+  bid 		= blockIdx.x;
+
+  for(ind=0; ind<Nspikes;ind++)
+      if (id[ind]==bid){
+          my_chan = call[ind];
+          this_chan = iC[tidy + NchanNear * my_chan];
+          xsum = uproj[tidx + NrankPC*tidy +  NrankPC*NchanNear * ind];
+          WU[tidx + NrankPC*this_chan + NrankPC*Nchan * bid] +=  xsum;
+      }
+   }
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
+__global__ void average_snips_v3(const double *Params, const int *ioff, const int *id, const float *uproj,
+        const float *cmax, float *bigArray){
+
+
+  // jic, version to work with Nfeatures threads
+  // have made a big array of Nfeature*NfeatW*Nfilters so projections
+  // onto each Nfeature can be summed without collisions
+  // after running this, need to sum up each set of Nfeature subArrays
+  // to calculate the final NfeatW*Nfilters array
+
+  int tid, bid, ind, Nspikes, Nfeatures, NfeatW;
+  float xsum = 0.0f;
+
+  Nspikes               = (int) Params[0];
+  Nfeatures             = (int) Params[1];
+  NfeatW                = (int) Params[4];
+
+  tid       = threadIdx.x;      //feature index
+  bid 		= blockIdx.x;       //filter index
+
+
+
+
+
+  for(ind=0; ind<Nspikes;ind++) {
+
+      if (id[ind]==bid){
+            //uproj is Nfeatures x Nspikes
+            xsum = uproj[tid + Nfeatures * ind];
+            //add this to the Nfeature-th array of NfeatW at the offset for this spike
+            bigArray[ioff[ind] + tid + tid*NfeatW + Nfeatures*NfeatW * bid] +=  xsum;
+      }  //end of if block for  match
+  }     //end of loop over spikes
+
+}
+
+
+
+__global__ void sum_dWU(const double *Params, const float *bigArray, float *WU) {
+
+  int tid,bid, ind, Nfilters, Nthreads, Nfeatures, Nblocks, NfeatW, nWU, nElem;
+  float sum = 0.0f;
+
+  Nfeatures             = (int) Params[1];
+  NfeatW                = (int) Params[4];
+  Nfilters              = (int) Params[2];
+  Nthreads              = blockDim.x;
+  Nblocks               = gridDim.x;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+
+  //WU is NfeatW x Nfilters.
+
+  nWU = NfeatW * Nfilters;
+  nElem = Nfeatures*NfeatW; //number of elements in each subArray of bigArray
+
+  //Calculate which element we're addressing
+  int tind = tid + bid * Nthreads;
+
+  int currFilt, currFW, currIndex;
+  while (tind < nWU){
+
+
+      //which filter and element of WU?
+      currFilt = floor((double)(tind/NfeatW));
+      currFW = tind - currFilt*NfeatW;
+
+      //Sum up the Nfeature elements of bigArray that correspond to this
+      //filter and NfeatW
+
+      sum = 0.0f;
+
+      for(ind=0; ind<Nfeatures; ind++) {
+          //bigArray is Nfilter arrays of Nfeature x NfeatW;
+          currIndex = currFilt*nElem + ind*NfeatW + currFW;
+          sum += bigArray[ currIndex ];
+      }
+
+      WU[tind] += sum;
+      tind += Nblocks*Nthreads;
+
+   }
+
+}
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void count_spikes(const double *Params, const int *id, int *nsp, const float *x, float *V){
+
+  int tid, tind, bid, ind, Nspikes, Nfilters, NthreadsMe, Nblocks;
+
+  Nspikes               = (int) Params[0];
+  Nfilters             = (int) Params[2];
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NthreadsMe              = blockDim.x;
+  Nblocks               = gridDim.x;
+
+  tind = tid + NthreadsMe *bid;
+
+  while (tind<Nfilters){
+      for(ind=0; ind<Nspikes;ind++)
+          if (id[ind]==tind){
+              nsp[tind] ++;
+              V[tind] += x[tind];
+          }
+      V[tind] = V[tind] / (.001f + (float) nsp[tind]);
+
+      tind += NthreadsMe * Nblocks;
+  }
+
+
+}

--- a/pykilosort/cuda/mexDistances2.cu
+++ b/pykilosort/cuda/mexDistances2.cu
@@ -1,0 +1,70 @@
+__global__ void computeCost(const double *Params, const float *Ws, const float *mus,
+        const float *W, const float *mu, const bool *iMatch,
+        const int *iC, const int *Wh, float *cmax){
+
+  int j, tid, bid, Nspikes, my_chan, this_chan, Nchan, NrankPC, NchanNear, Nthreads, k;
+  float xsum = 0.0f, Ci;
+
+  Nspikes               = (int) Params[0];
+  Nchan                 = (int) Params[7];
+  NrankPC                 = (int) Params[1];
+  NchanNear                 = (int) Params[6];
+  Nthreads              = blockDim.x;
+
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  while(tid<Nspikes){
+      my_chan = Wh[tid];
+      if (iMatch[my_chan + bid*Nchan]){
+          xsum = 0.0f;
+          for (k=0;k<NchanNear;k++){
+              this_chan = iC[k + NchanNear * my_chan];
+              for (j=0;j<NrankPC;j++)
+                    xsum += Ws[j + NrankPC*k + NrankPC*NchanNear * tid] *
+                            W[j + NrankPC*this_chan + NrankPC*Nchan * bid];
+
+          }
+
+          Ci = mu[bid]*mu[bid] + mus[tid]*mus[tid] -2*mus[tid]*mu[bid]*xsum;
+          cmax[tid + bid*Nspikes] = Ci;
+      }
+      tid+= Nthreads;
+  }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void bestFilter(const double *Params, const bool *iMatch,
+        const int *Wh, const float *cmax, const float *mus, int *id, float *x){
+
+  int tid,tind,bid, my_chan, ind, Nspikes, Nfilters, Nthreads, Nchan, Nblocks;
+  float max_running = 0.0f;
+
+  Nspikes               = (int) Params[0];
+  Nfilters              = (int) Params[2];
+  Nchan                 = (int) Params[7];
+  Nthreads              = blockDim.x;
+  Nblocks               = gridDim.x;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  tind = tid + bid * Nthreads;
+
+  while (tind<Nspikes){
+      max_running = mus[tind] * mus[tind];
+      id[tind] = 0;
+      my_chan = Wh[tind];
+      for(ind=0; ind<Nfilters; ind++)
+          if (iMatch[my_chan + ind * Nchan])
+              if (cmax[tind + ind*Nspikes] < max_running){
+                  id[tind] = ind;
+                  max_running = cmax[tind + ind*Nspikes];
+              }
+      x[tind] = max_running;
+      tind += Nblocks*Nthreads;
+  }
+
+}

--- a/pykilosort/cuda/mexGetSpikes2.cu
+++ b/pykilosort/cuda/mexGetSpikes2.cu
@@ -1,0 +1,256 @@
+const int  Nthreads = 1024, maxFR = 5000, NrankMax = 6;
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void  sumChannels(const double *Params, const float *data,
+	float *datasum, int *kkmax, const int *iC){
+
+  int tid, tid0,t, kmax, i, bid, NT, Nchan, NchanNear,j,iChan, Nsum, Nrank;
+  float  Cf, Cmax;
+
+  NchanNear = (int) Params[10];
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NT 		= (int) Params[0];
+  Nchan     = (int) Params[9];
+  Nsum      = (int) Params[13];
+  Nrank     = (int) Params[14];
+
+  tid0 = tid + bid * blockDim.x;
+  while (tid0<NT){
+      for (i=0; i<Nchan;i++){
+          Cmax = 0.0f;
+          kmax = 0;
+          for (t=0;t<Nrank;t++){
+              Cf = 0.0f;
+              for(j=0; j<Nsum; j++){
+                  iChan = iC[j+ NchanNear * i];
+                  Cf    += data[tid0 + NT * iChan + t * NT * Nchan];
+                  if (Cf*Cf/(1+j) > Cmax){
+                      Cmax = Cf*Cf /(1+j);
+                      kmax = j + t*Nsum;
+                   }
+              }
+          }
+          datasum[tid0 + NT * i] = Cmax;
+          kkmax[tid0 + NT * i]   = kmax;
+      }
+      tid0 += blockDim.x * gridDim.x;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	Conv1D(const double *Params, const float *data, const float *W, float *conv_sig){
+    volatile __shared__ float  sW[81*NrankMax], sdata[(Nthreads+81)];
+    float y;
+    int tid, tid0, bid, i, nid, Nrank, NT, nt0,  Nchan;
+
+    tid 		= threadIdx.x;
+    bid 		= blockIdx.x;
+    NT      	=   (int) Params[0];
+    Nrank     = (int) Params[14];
+    nt0       = (int) Params[4];
+    Nchan     = (int) Params[9];
+
+    if(tid<nt0*Nrank)
+        sW[tid]= W[tid];
+    __syncthreads();
+
+    tid0 = 0;
+    while (tid0<NT-Nthreads-nt0+1){
+        if (tid<nt0)
+            sdata[tid] = data[tid0 + tid + NT*bid];
+        sdata[tid + nt0] = data[nt0+tid0 + tid+ NT*bid];
+        __syncthreads();
+
+        for(nid=0;nid<Nrank;nid++){
+            y = 0.0f;
+            #pragma unroll 4
+            for(i=0;i<nt0;i++)
+                y    += sW[i + nid*nt0] * sdata[i+tid];
+            conv_sig[tid0  + tid + NT*bid + nid * NT * Nchan]   = y;
+        }
+        tid0+=Nthreads;
+        __syncthreads();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void  bestFilter(const double *Params, const float *data,
+	float *err, int *ftype, int *kkmax, int *kall){
+
+  int tid, tid0, i, bid, NT, Nchan, ibest = 0, kbest;
+  float  Cf, Cbest = 0.0f;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NT 		= (int) Params[0];
+  Nchan     = (int) Params[9];
+
+  tid0 = tid + bid * blockDim.x;
+  while (tid0<NT){
+      kbest = 0;
+      for (i=0; i<Nchan;i++){
+          Cf = data[tid0 + NT*i];
+          if (Cf > Cbest + 1e-6){
+              Cbest 	= Cf;
+              ibest 	= i;
+              kbest 	= kkmax[tid0 + NT*i];
+          }
+      }
+      err[tid0] 	= Cbest;
+      ftype[tid0] 	= ibest;
+      kall[tid0] 	= kbest;
+
+      tid0 += blockDim.x * gridDim.x;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	cleanup_spikes(const double *Params, const float *err,
+	const int *ftype, float *x, int *st, int *id, int *counter){
+
+  int lockout, indx, tid, bid, NT, tid0,  j, t0;
+  volatile __shared__ float sdata[Nthreads+2*81+1];
+  bool flag=0;
+  float err0, Th;
+
+  lockout   = (int) Params[4] - 1;
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  NT      	=   (int) Params[0];
+  tid0 		= bid * blockDim.x ;
+  Th 		= (float) Params[2];
+
+  while(tid0<NT-Nthreads-lockout+1){
+      if (tid<2*lockout)
+          sdata[tid] = err[tid0 + tid];
+      if (tid0+tid+2*lockout<NT)
+          sdata[tid+2*lockout] = err[2*lockout + tid0 + tid];
+      else
+          sdata[tid+2*lockout] = 0.0f;
+
+          __syncthreads();
+
+      err0 = sdata[tid+lockout];
+      t0 = tid+lockout         + tid0;
+      if(err0 > Th*Th && t0<NT-lockout-1){
+          flag = 0;
+          for(j=-lockout;j<=lockout;j++)
+              if(sdata[tid+lockout+j]>err0){
+                  flag = 1;
+                  break;
+              }
+          if(flag==0){
+              indx = atomicAdd(&counter[0], 1);
+              if (indx<maxFR){
+                  st[indx] = t0;
+                  id[indx] = ftype[t0];
+                  x[indx]  = err0;
+              }
+          }
+      }
+
+      tid0 = tid0 + blockDim.x * gridDim.x;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	cleanup_heights(const double *Params, const float *x,
+        const int *st, const int *id, int *st1, int *id1, int *counter){
+
+  int indx, tid, bid, t, d, Nmax;
+  volatile __shared__ float s_id[maxFR], s_x[maxFR];
+  bool flag=0;
+  float xmax;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  Nmax = min(maxFR, counter[0]);
+
+  while (tid<Nmax){
+      s_x[tid]  = x[tid];
+      s_id[tid] = id[tid];
+      tid+=blockDim.x;
+  }
+  __syncthreads();
+
+  tid = bid*blockDim.x + threadIdx.x;
+
+  if (tid<Nmax){
+      xmax = s_x[tid];
+      flag = 1;
+      for (t=0; t<Nmax;t++){
+          d = abs(s_id[t] - s_id[tid]);
+          if (d<5 && xmax< s_x[t]){
+              flag = 0;
+                break;
+          }
+      }
+      // if flag, then your thread is the max across nearby channels
+      if(flag){
+          indx = atomicAdd(&counter[1], 1);
+          if (indx<maxFR){
+              st1[indx] = st[tid];
+              id1[indx] = s_id[tid];
+          }
+      }
+  }
+
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void extract_snips(const double *Params, const int *st, const int *id,
+        const int *counter, const float *dataraw,  float *WU){
+
+  int nt0, tidx, tidy, bid, ind, NT, Nchan, Nmax;
+
+  NT        = (int) Params[0];
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+
+  tidx 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  Nmax = min(maxFR, counter[1]);
+
+  for(ind=0; ind<Nmax;ind++)
+      if (id[ind]==bid){
+		  tidy 		= threadIdx.y;
+		  while (tidy<Nchan){
+            WU[tidx+tidy*nt0 + nt0*Nchan * ind] = dataraw[st[ind]+tidx + NT * tidy];
+			tidy+=blockDim.y;
+		  }
+	  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void extract_snips2(const double *Params, const float *err, const int *st, const int *id,
+        const int *counter, const int *kk, const int *iC, const float *W, float *WU){
+
+  int nt0, tidx, tidy, bid, ind, icl, Nchan, Nmax, Nsum, NchanNear;
+
+  //NT        = (int) Params[0];
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+  Nsum      = (int) Params[13];
+  NchanNear = (int) Params[10];
+
+  tidx 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  Nmax = min(maxFR, counter[1]);
+
+  for(ind=0; ind<Nmax;ind++)
+      if (id[ind]==bid){
+		  tidy 		= threadIdx.y;
+          icl = kk[st[ind]];
+
+		  while (tidy<(1+icl%Nsum)){
+            //WU[tidx+tidy*nt0 + nt0*Nchan * ind] = dataraw[st[ind]+tidx + NT * tidy];
+              WU[tidx + iC[tidy + bid*NchanNear]*nt0 + nt0*Nchan*ind] =
+                      sqrt(err[st[ind]] / (1.+icl%Nsum)) * W[tidx + nt0 * int(icl/Nsum)];
+			tidy+=blockDim.y;
+		  }
+	  }
+}

--- a/pykilosort/cuda/mexMPnu8.cu
+++ b/pykilosort/cuda/mexMPnu8.cu
@@ -1,0 +1,523 @@
+const int  Nthreads = 1024, maxFR = 100000, NrankMax = 3, nmaxiter = 500, NchanMax = 32;
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	spaceFilter(const double *Params, const float *data, const float *U,
+        const int *iC, const int *iW, float *dprod){
+  volatile __shared__ float  sU[32*NrankMax];
+  volatile __shared__ int iU[32];
+  float x;
+  int tid, bid, i,k, Nrank, Nchan, NT, Nfilt, NchanU;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NT      	=   (int) Params[0];
+  Nfilt    	=   (int) Params[1];
+  Nrank     = (int) Params[6];
+  NchanU    = (int) Params[10];
+  Nchan     = (int) Params[9];
+
+  if (tid<NchanU)
+      iU[tid] = iC[tid + NchanU * iW[bid]];
+  __syncthreads();
+
+  if(tid<NchanU*Nrank)
+      sU[tid]= U[iU[tid%NchanU] + Nchan * bid + Nchan * Nfilt * (tid/NchanU)];
+
+  //sU[tid]= U[tid%NchanU + NchanU * bid + NchanU * Nfilt * (tid/NchanU)];
+
+  __syncthreads();
+
+  while (tid<NT){
+      for (k=0;k<Nrank;k++){
+          x = 0.0f;
+          for(i=0;i<NchanU;i++)
+              x  += sU[i + NchanU*k] * data[tid + NT * iU[i]];
+          dprod[tid + NT*bid + k*NT*Nfilt]   = x;
+      }
+
+      tid += blockDim.x;
+      __syncthreads();
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	spaceFilterUpdate(const double *Params, const float *data, const float *U, const bool *UtU,
+        const int *iC, const int *iW, float *dprod,  const int *st, const int *id, const int *counter){
+    volatile __shared__ float  sU[32*NrankMax];
+    volatile __shared__ int iU[32];
+    float x;
+    int tid, bid, ind, nt0, i, t, k, Nrank, NT, Nfilt, NchanU, Nchan;
+
+    tid 		= threadIdx.x;
+    bid 		= blockIdx.x;
+    NT      	= (int) Params[0];
+    Nfilt    	= (int) Params[1];
+    Nrank     = (int) Params[6];
+    NchanU    = (int) Params[10];
+    nt0       = (int) Params[4];
+    Nchan     = (int) Params[9];
+
+    // just need to do this for all filters that have overlap with id[bid] and st[id]
+    // tidx still represents time, from -nt0 to nt0
+    // tidy loops through all filters that have overlap
+
+    if (tid<NchanU)
+        iU[tid] = iC[tid + NchanU * iW[bid]];
+    __syncthreads();
+
+    if (tid<NchanU)
+       for (k=0;k<Nrank;k++)
+            sU[tid + k * NchanU] = U[iU[tid] + Nchan * bid + Nchan * Nfilt * k];
+
+    __syncthreads();
+
+    for(ind=counter[1];ind<counter[0];ind++)
+        if (UtU[id[ind] + Nfilt *bid]){
+            t = st[ind] + tid - nt0;
+            // if this is a hit, threads compute all time offsets
+            if (t>=0 & t<NT){
+                for (k=0;k<Nrank;k++){
+                    x = 0.0f;
+                    for(i=0;i<NchanU;i++)
+                        x  += sU[i + NchanU*k] * data[t + NT * iU[i]];
+                    dprod[t + NT*bid + k*NT*Nfilt]   = x;
+                }
+            }
+        }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	timeFilter(const double *Params, const float *data, const float *W,float *conv_sig){
+  volatile __shared__ float  sW2[81*NrankMax], sW[81*NrankMax], sdata[(Nthreads+81)*NrankMax];
+  float x;
+  int tid, tid0, bid, i, nid, Nrank, NT, Nfilt, nt0;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NT      	=   (int) Params[0];
+  Nfilt    	=   (int) Params[1];
+  Nrank     = (int) Params[6];
+  nt0       = (int) Params[4];
+
+  if(tid<nt0*Nrank)
+      sW[tid]  = W[tid%nt0 + (bid + Nfilt * (tid/nt0))* nt0];
+
+  __syncthreads();
+
+  tid0 = 0;
+  while (tid0<NT-Nthreads-nt0+1){
+	  if (tid<nt0*NrankMax)
+          sdata[tid%nt0 + (tid/nt0)*(Nthreads+nt0)] =
+			data[tid0 + tid%nt0+ NT*(bid + Nfilt*(tid/nt0))];
+
+      #pragma unroll 3
+      for(nid=0;nid<Nrank;nid++){
+          sdata[tid + nt0+nid*(Nthreads+nt0)] = data[nt0+tid0 + tid+ NT*(bid +nid*Nfilt)];
+	  }
+	  __syncthreads();
+
+	  x = 0.0f;
+      for(nid=0;nid<Nrank;nid++){
+		  #pragma unroll 4
+          for(i=0;i<nt0;i++)
+              x    += sW[i + nid*nt0]  * sdata[i+tid + nid*(Nthreads+nt0)];
+	  }
+      conv_sig[tid0  + tid + NT*bid]              = x;
+
+      tid0+=Nthreads;
+      __syncthreads();
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	timeFilterUpdate(const double *Params, const float *data, const float *W,
+        const bool *UtU, float *conv_sig, const int *st, const int *id, const int *counter){
+
+  volatile __shared__ float  sW[81*NrankMax], sW2[81*NrankMax];
+  float x;
+  int tid, tid0, bid, t, k,ind, Nrank, NT, Nfilt, nt0;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NT      	=   (int) Params[0];
+  Nfilt    	=   (int) Params[1];
+  Nrank     = (int) Params[6];
+  nt0       = (int) Params[4];
+
+   if (tid<nt0)
+       for (k=0;k<Nrank;k++)
+           sW[tid + k*nt0]= W[tid + nt0*bid + nt0*Nfilt * k];
+  __syncthreads();
+
+  for(ind=counter[1];ind<counter[0];ind++)
+      if (UtU[id[ind] + Nfilt *bid]){
+          tid0 = st[ind] - nt0 + tid;
+          if (tid0>=0 && tid0<NT-nt0){
+              x = 0.0f;
+              for (k=0;k<Nrank;k++)
+                  for (t=0;t<nt0;t++)
+                      x += sW[t +k*nt0] * data[t + tid0 + NT * bid + NT * Nfilt *k];
+
+              conv_sig[tid0 + NT*bid]   = x;
+          }
+
+      }
+
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void  bestFilter(const double *Params, const float *data,
+	const float *mu, float *err, float *eloss, int *ftype){
+  int tid, tid0, i, bid, NT, Nfilt, ibest = 0, nt0;
+  float  Cf, Cbest, lam, b, a, Cnextbest;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+  NT 		= (int) Params[0];
+  Nfilt 	= (int) Params[1];
+  lam 	    = (float) Params[7];
+  nt0       = (int) Params[4];
+
+  tid0 = tid + bid * blockDim.x;
+  while (tid0<NT-nt0){
+      Cbest = 0.0f;
+      Cnextbest = 0.0f;
+
+      for (i=0; i<Nfilt;i++){
+
+          a = 1+ lam;
+          b = max(0.0f, data[tid0 + NT * i]) + lam * mu[i];
+          Cf =  b*b/a - lam * mu[i]*mu[i];
+
+          if (Cf > Cbest + 1e-6){
+              Cnextbest = Cbest;
+              Cbest 	= Cf;
+              ibest 	= i;
+          }
+          else
+              if  (Cf > Cnextbest + 1e-6)
+                    Cnextbest = Cf;
+      }
+      err[tid0] 	= Cbest;
+      eloss[tid0] 	= Cbest - Cnextbest;
+      ftype[tid0] 	= ibest;
+
+      tid0 += blockDim.x * gridDim.x;
+  }
+}
+
+// THIS UPDATE DOES NOT UPDATE ELOSS?
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void  bestFilterUpdate(const double *Params, const float *data,
+	const float *mu, float *err, float *eloss, int *ftype, const int *st, const int *id, const int *counter){
+  int tid,  ind, i,t, NT, Nfilt, ibest = 0, nt0;
+  float  Cf, Cbest, lam, b, a, Cnextbest;
+
+  tid 		= threadIdx.x;
+  NT 		= (int) Params[0];
+  Nfilt 	= (int) Params[1];
+  lam 	    = (float) Params[7];
+  nt0       = (int) Params[4];
+
+
+  // we only need to compute this at updated locations
+  ind = counter[1] + blockIdx.x;
+
+  if (ind<counter[0]){
+      t = st[ind]-nt0 + tid;
+      if (t>=0 && t<NT){
+          Cbest = 0.0f;
+          for (i=0; i<Nfilt;i++){
+              a = 1+ lam;
+              b = max(0.0f, data[t + NT * i]) + lam * mu[i];
+
+              Cf =  b*b/a - lam * mu[i]*mu[i];
+
+               if (Cf > Cbest + 1e-6){
+                  Cnextbest = Cbest;
+                  Cbest 	= Cf;
+                  ibest 	= i;
+              }
+              else
+                  if  (Cf > Cnextbest + 1e-6)
+                      Cnextbest = Cf;
+          }
+          err[t] 	= Cbest;
+          ftype[t] 	= ibest;
+      }
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	cleanup_spikes(const double *Params, const float *data,
+        const float *mu, const float *err, const float *eloss, const int *ftype, int *st,
+        int *id, float *x, float *y,  float *z, int *counter){
+
+  int lockout, indx, tid, bid, NT, tid0,  j, id0, t0;
+  volatile __shared__ float sdata[Nthreads+2*81+1];
+  bool flag=0;
+  float err0, Th;
+
+  lockout   = (int) Params[4] - 1;
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  NT      	=   (int) Params[0];
+  tid0 		= bid * blockDim.x ;
+  Th 		= (float) Params[2];
+  //lam 	    = (float) Params[7];
+
+  while(tid0<NT-Nthreads-lockout+1){
+      if (tid<2*lockout)
+          sdata[tid] = err[tid0 + tid];
+      sdata[tid+2*lockout] = err[2*lockout + tid0 + tid];
+
+      __syncthreads();
+
+      err0 = sdata[tid+lockout];
+      if(err0>Th*Th){
+          flag = 0;
+          for(j=-lockout;j<=lockout;j++)
+              if(sdata[tid+lockout+j]>err0){
+                  flag = 1;
+                  break;
+              }
+          if(flag==0){
+              indx = atomicAdd(&counter[0], 1);
+              if (indx<maxFR){
+                  t0        = tid+lockout+tid0;
+                  id0       = ftype[t0];
+                  st[indx] = t0;
+                  id[indx] = id0;
+                  y[indx]  = data[t0 + NT * id0];
+
+                  //a = 1+ lam;
+                  //b = max(0.0f, data[t0 + NT * id0]) + lam * mu[id0];
+
+                  x[indx] = sqrt(err0);
+                  //x[indx]  = b/a;    // do I really need this here?
+                  //x[indx]  = y[indx];
+                  z[indx]  = eloss[t0];
+              }
+          }
+      }
+
+      tid0 += blockDim.x * gridDim.x;
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	extractFEAT(const double *Params, const int *st, const int *id,
+        const int *counter, const float *dout, const int *iList,
+        const float *mu, float *d_feat){
+    int t, tidx, tidy,Nblocks,NthreadsX,idF, bid,  NT, ind, tcurr, Nnearest;
+    float rMax, Ci, Cf, lam;
+    tidx 		= threadIdx.x;
+    tidy 		= threadIdx.y;
+
+    bid 		= blockIdx.x;
+    NT 		= (int) Params[0];
+    Nnearest 	= (int) Params[5];
+    NthreadsX 	= blockDim.x;
+    Nblocks               = gridDim.x;
+    lam 	    = (float) Params[7];
+
+    // each thread x does a nearby filter
+    // each thread x combines with blocks to go through all new spikes
+    ind = counter[1]+tidx + NthreadsX * bid;
+
+    while(ind<counter[0]){
+        tcurr = st[ind];
+        rMax = 0.0f;
+        idF = iList[tidy + Nnearest * id[ind]];
+
+        for (t=-3;t<3;t++){
+            Ci = dout[tcurr +t+ idF * NT] + lam/mu[idF];
+            Cf = Ci / sqrt(lam/(mu[idF] * mu[idF]) + 1.0f);
+            rMax = max(rMax, Cf);
+        }
+        d_feat[tidy + ind * Nnearest] = rMax;
+        ind += NthreadsX * Nblocks;
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	subtract_spikes(const double *Params,  const int *st,
+        const int *id, const float *x, const int *counter, float *dataraw,
+        const float *W, const float *U){
+  int nt0, tidx, tidy, k, NT, ind, Nchan, Nfilt, Nrank;
+  float X;
+
+  NT        = (int) Params[0];
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+  Nfilt    	=   (int) Params[1];
+  Nrank     = (int) Params[6];
+
+  tidx 		= threadIdx.x;
+  ind       = counter[1]+blockIdx.x;
+
+  while(ind<counter[0]){
+      tidy = threadIdx.y;
+
+      while (tidy<Nchan){
+          X = 0.0f;
+          for (k=0;k<Nrank;k++)
+              X += W[tidx + id[ind]* nt0 + nt0*Nfilt*k] *
+                      U[tidy + id[ind] * Nchan + Nchan*Nfilt*k];
+
+          dataraw[tidx + st[ind] + NT * tidy] -= x[ind] * X;
+          tidy += blockDim.y;
+      }
+      ind += gridDim.x;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void average_snips(const double *Params, const int *st,
+        const int *id,  const float *x, const float *y,  const int *counter, const float *dataraw,
+        const float *W, const float *U, double *WU, int *nsp,
+        const float *mu, const float *z){
+
+  int nt0, tidx, tidy, bid, NT, Nchan,k, Nrank, Nfilt;
+  int currInd;
+  float Th;
+  double  X, xsum;
+
+  NT        = (int) Params[0];
+  Nfilt    	=   (int) Params[1];
+  nt0       = (int) Params[4];
+  Nrank     = (int) Params[6];
+  Nchan     = (int) Params[9];
+
+  tidx 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  //Th = 10.f;
+  Th 		= (float) Params[15];
+
+  // we need wPCA projections in here, and then to decide based on total
+
+  // idx is the time sort order of the spikes; the original order is a function
+  // of when threads complete in mexGetSpikes. Compilation of the sums for WU, sig, and dnextbest
+  // in a fixed order makes the calculation deterministic.
+
+  for(currInd=0; currInd<counter[0];currInd++) {
+      // only do this if the spike is "GOOD"
+      if (x[currInd]>Th){
+          if (id[currInd]==bid){
+              if (tidx==0 &&  threadIdx.y==0)
+                  nsp[bid]++;
+
+              tidy 		= threadIdx.y;
+              while (tidy<Nchan){
+                  X = 0.0f;
+                  for (k=0;k<Nrank;k++)
+                      X += W[tidx + bid* nt0 + nt0*Nfilt*k] *
+                              U[tidy + bid * Nchan + Nchan*Nfilt*k];
+
+                  xsum = dataraw[st[currInd]+tidx + NT * tidy] + y[currInd] * X;
+
+                  //WU[tidx+tidy*nt0 + nt0*Nchan * bid] *= p[bid];
+                  WU[tidx+tidy*nt0 + nt0*Nchan * bid] += (double) xsum;
+
+                  tidy+=blockDim.y;
+
+              }        //end of while loop over channels
+          }               //end of if block for id == bid
+      }
+  }                  //end of for loop over spike indicies
+}                      //end of function
+
+
+
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	computePCfeatures(const double *Params, const int *counter,
+        const float *dataraw,  const int *st, const int *id, const float *x,
+        const float *W, const float *U, const float *mu, const int *iW, const int *iC,
+        const float *wPCA, float *featPC){
+
+  volatile __shared__ float  sPCA[81 * NrankMax], sW[81 * NrankMax], sU[NchanMax * NrankMax];
+  volatile __shared__ int iU[NchanMax];
+
+  int bid, nt0, t, tidx, tidy, k, NT, ind, Nchan, NchanU, Nfilt, Nrank;
+  float X = 0.0f, Y = 0.0f;
+
+  NT        = (int) Params[0];
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+  Nfilt    	= (int) Params[1];
+  Nrank     = (int) Params[6];
+  NchanU    = (int) Params[10];
+
+  tidx 		= threadIdx.x;
+  tidy 		= threadIdx.y;
+  bid       = blockIdx.x;
+
+  if (tidy==0)
+      iU[tidx] = iC[tidx + NchanU * iW[bid]];
+  __syncthreads();
+
+  sU[tidx + tidy*NchanU]= U[iU[tidx] + Nchan * bid + Nchan * Nfilt * tidy];
+
+  while (tidx<nt0){
+     sW[tidx + tidy*nt0]  = W[tidx + bid*nt0 + Nfilt * nt0 * tidy];
+      sPCA[tidx + tidy*nt0]  = wPCA[tidx + nt0 * tidy];
+      tidx += blockDim.x;
+  }
+
+  tidx 		= threadIdx.x;
+  __syncthreads();
+
+//   first, compute wPCA projections of the filter
+  Y = 0.0f;
+  for (k =0; k<Nrank; k++){
+      X = 0.0f;
+      for (t=0;t<nt0;t++)
+          X += sW[t + k*nt0] * sPCA[t + tidy * nt0];
+      Y += X * sU[tidx + k*NchanU];
+  }
+
+  //now for each matching spike, compute the features
+  for(ind=0; ind<counter[0];ind++)
+      if (id[ind]==bid){
+          X = Y * x[ind]; // - mu[bid]);
+          for (t=0;t<nt0; t++)
+              X  += dataraw[st[ind] + t + NT * iU[tidx]] * sPCA[t + nt0*tidy];
+          featPC[tidx + tidy*NchanU + ind * NchanU*Nrank] = X;
+      }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	addback_spikes(const double *Params,  const int *st,
+        const int *id, const float *x, const int *count, float *dataraw,
+        const float *W, const float *U, const int iter, const float *spkscore){
+  int nt0, tidx, tidy, k, NT, ind, Nchan, Nfilt, Nrank;
+  float X, ThS;
+
+  NT        = (int) Params[0];
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+  Nfilt    	=   (int) Params[1];
+  Nrank     = (int) Params[6];
+  ThS      = (float) Params[11];
+
+  tidx 		= threadIdx.x;
+  ind       = count[iter]+blockIdx.x;
+
+  while(ind<count[iter+1]){
+      if (spkscore[ind]>ThS){
+
+          tidy = threadIdx.y;
+          // only do this if the spike is "BAD"
+          while (tidy<Nchan){
+              X = 0.0f;
+              for (k=0;k<Nrank;k++)
+                  X += W[tidx + id[ind]* nt0 + nt0*Nfilt*k] *
+                          U[tidy + id[ind] * Nchan + Nchan*Nfilt*k];
+
+              dataraw[tidx + st[ind] + NT * tidy] += x[ind] * X;
+              tidy += blockDim.y;
+          }
+      }
+      ind += gridDim.x;
+  }
+}

--- a/pykilosort/cuda/mexSVDsmall2.cu
+++ b/pykilosort/cuda/mexSVDsmall2.cu
@@ -1,0 +1,255 @@
+const int  Nthreads = 1024,  NrankMax = 3, nt0max = 71, NchanMax = 1024;
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void blankdWU(const double *Params, const double *dWU,
+        const int *iC, const int *iW, double *dWUblank){
+
+  int nt0, tidx, tidy, bid, Nchan, NchanNear, iChan;
+
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+  NchanNear = (int) Params[10];
+
+  tidx 		= threadIdx.x;
+  tidy 		= threadIdx.y;
+
+  bid 		= blockIdx.x;
+
+  while (tidy<NchanNear){
+      iChan = iC[tidy+ NchanNear * iW[bid]];
+      dWUblank[tidx + nt0*iChan + bid * nt0 * Nchan] =
+              dWU[tidx + nt0*iChan + bid * nt0 * Nchan];
+      tidy+=blockDim.y;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void getwtw(const double *Params, const double *dWU, double *wtw){
+
+  int nt0, tidx, tidy, bid, Nchan,k;
+  double x;
+
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+
+  tidx 		= threadIdx.x;
+  tidy 		= threadIdx.y;
+
+  bid 		= blockIdx.x;
+
+  while (tidy<nt0){
+      x = 0.0f;
+      for (k=0; k<Nchan; k++)
+          x += dWU[tidx + k*nt0 + bid * Nchan*nt0] *
+                  dWU[tidy + k*nt0 + bid * Nchan*nt0];
+      wtw[tidx + tidy*nt0 + bid * nt0*nt0] = x;
+
+      tidy+=blockDim.y;
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void getU(const double *Params, const double *dWU, double *W, double *U){
+
+  int Nfilt, nt0, tidx, tidy, bid, Nchan,k;
+  double x;
+
+
+  nt0       = (int) Params[4];
+  Nchan     = (int) Params[9];
+  Nfilt    	=   (int) Params[1];
+  tidx 		= threadIdx.x;
+  tidy 		= threadIdx.y;
+  bid 		= blockIdx.x;
+
+  while (tidy<Nchan){
+      x = 0.0f;
+      for (k=0; k<nt0; k++)
+          x += W[k + nt0*bid + nt0*Nfilt*tidx] *
+                  dWU[k + tidy*nt0 + bid * Nchan*nt0];
+      U[tidy + Nchan * bid + Nchan * Nfilt * tidx] = x;
+
+      tidy+=blockDim.y;
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void getW(const double *Params, double *wtw, double *W){
+
+  int Nfilt, nt0, tid, bid, i, t, Nrank,k, tmax;
+  double x, x0, xmax;
+  volatile __shared__ double sW[nt0max*NrankMax], swtw[nt0max*nt0max], xN[1];
+
+  nt0       = (int) Params[4];
+   Nrank       = (int) Params[6];
+  Nfilt    	=   (int) Params[1];
+  tmax = (int) Params[11];
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  for (k=0;k<nt0;k++)
+      swtw[tid + k*nt0] = wtw[tid + k*nt0 + bid * nt0 * nt0];
+  for (k=0;k<Nrank;k++)
+      sW[tid + k*nt0] = W[tid + bid * nt0  + k * nt0*Nfilt];
+  __syncthreads();
+
+
+  // for each svd
+  for(k=0;k<Nrank;k++){
+      for (i=0;i<100;i++){
+          // compute projection of wtw
+          x = 0.0f;
+          for (t=0;t<nt0;t++)
+              x+= swtw[tid + t*nt0] * sW[t + k*nt0];
+
+          __syncthreads();
+          if (i<99){
+              sW[tid + k*nt0] = x;
+              __syncthreads();
+
+              if (tid==0){
+                  x0 = 0.00001f;
+                  for(t=0;t<nt0;t++)
+                      x0+= sW[t + k*nt0] * sW[t + k*nt0];
+                  xN[0] = sqrt(x0);
+              }
+              __syncthreads();
+
+              sW[tid + k*nt0] = x/xN[0];
+              __syncthreads();
+          }
+      }
+
+      // now subtract off this svd from wtw
+      for (t=0;t<nt0;t++)
+          swtw[tid + t*nt0] -= sW[t+k*nt0] * x;
+
+      __syncthreads();
+  }
+
+
+  xmax = sW[tmax];
+  __syncthreads();
+
+  sW[tid] = - sW[tid] * copysign(1.0, xmax);
+
+  // now write W back
+  for (k=0;k<Nrank;k++)
+      W[tid + bid * nt0  + k * nt0*Nfilt] = sW[tid + k*nt0];
+
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void reNormalize(const double *Params, const double *A, const double *B,
+        double *W, double *U, double *mu){
+
+    int Nfilt, nt0, tid, bid, Nchan,k, Nrank, imax, t, ishift, tmax;
+    double x, xmax, xshift, sgnmax;
+
+    volatile __shared__ double sW[NrankMax*nt0max], sU[NchanMax*NrankMax], sS[NrankMax+1],
+            sWup[nt0max*10];
+
+    nt0       = (int) Params[4];
+    Nchan     = (int) Params[9];
+    Nfilt     = (int) Params[1];
+    Nrank     = (int) Params[6];
+    tmax = (int) Params[11];
+    bid 	  = blockIdx.x;
+
+    tid 		= threadIdx.x;
+    for(k=0;k<Nrank;k++)
+        sW[tid + k*nt0] = W[tid + bid*nt0 + k*Nfilt*nt0];
+
+    while (tid<Nchan*Nrank){
+        sU[tid] = U[tid%Nchan + bid*Nchan  + (tid/Nchan)*Nchan*Nfilt];
+        tid += blockDim.x;
+    }
+
+    __syncthreads();
+
+    tid 		= threadIdx.x;
+    if (tid<Nrank){
+        x = 0.0f;
+        for (k=0; k<Nchan; k++)
+            x += sU[k + tid*Nchan] * sU[k + tid*Nchan];
+        sS[tid] = sqrt(x);
+    }
+    // no need to sync here
+    if (tid==0){
+        x = 0.0000001f;
+        for (k=0;k<Nrank;k++)
+            x += sS[k] * sS[k];
+        sS[Nrank] = sqrt(x);
+        mu[bid] = sqrt(x);
+    }
+
+    __syncthreads();
+
+    // now re-normalize U
+    tid 		= threadIdx.x;
+
+    while (tid<Nchan*Nrank){
+        U[tid%Nchan + bid*Nchan  + (tid/Nchan)*Nchan*Nfilt] = sU[tid] / sS[Nrank];
+        tid += blockDim.x;
+    }
+
+    /////////////
+    __syncthreads();
+
+    // now align W
+    xmax = 0.0f;
+    imax = 0;
+    for(t=0;t<nt0;t++)
+        if (abs(sW[t]) > xmax){
+            xmax = abs(sW[t]);
+            imax = t;
+        }
+
+    tid 		= threadIdx.x;
+    // shift by imax - tmax
+    for (k=0;k<Nrank;k++){
+        ishift = tid + (imax-tmax);
+        ishift = (ishift%nt0 + nt0)%nt0;
+
+        xshift = sW[ishift + k*nt0];
+        W[tid + bid*nt0 + k*nt0*Nfilt] = xshift;
+    }
+
+    __syncthreads();
+     for (k=0;k<Nrank;k++){
+        sW[tid + k*nt0] = W[tid + bid*nt0 + k*nt0*Nfilt];
+    }
+
+    /////////////
+    __syncthreads();
+
+        // now align W. first compute 10x subsample peak
+    tid 		= threadIdx.x;
+    if (tid<10){
+        sWup[tid] = 0;
+        for (t=0;t<nt0;t++)
+            sWup[tid] += A[tid + t*10] * sW[t];
+    }
+    __syncthreads();
+
+    xmax = 0.0f;
+    imax = 0;
+    sgnmax = 1.0f;
+    for(t=0;t<10;t++)
+        if (abs(sWup[t]) > xmax){
+            xmax = abs(sWup[t]);
+            imax = t;
+            sgnmax = copysign(1.0f, sWup[t]);
+        }
+
+    // interpolate by imax
+    for (k=0;k<Nrank;k++){
+        xshift = 0.0f;
+        for (t=0;t<nt0;t++)
+            xshift += B[tid + t*nt0 +nt0*nt0*imax] * sW[t + k*nt0];
+
+        if (k==0)
+            xshift = -xshift * sgnmax;
+
+        W[tid + bid*nt0 + k*nt0*Nfilt] = xshift;
+    }
+
+}

--- a/pykilosort/cuda/mexThSpkPC.cu
+++ b/pykilosort/cuda/mexThSpkPC.cu
@@ -1,0 +1,172 @@
+const int  Nthreads = 1024, maxFR = 10000, NrankMax = 3, nt0max=81, NchanMax = 17;
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	Conv1D(const double *Params, const float *data, const float *W, float *conv_sig){
+  volatile __shared__ float  sW[81*NrankMax], sdata[Nthreads+81];
+  float x, y;
+  int tid, tid0, bid, i, nid, Nrank, NT, nt0;
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  NT      	=   (int) Params[0];
+  nt0       = (int) Params[3];
+  Nrank     = (int) Params[6];
+
+  if(tid<nt0*Nrank)
+      sW[tid]= W[tid];
+  __syncthreads();
+
+  tid0 = 0;
+  while (tid0<NT-Nthreads-nt0+1){
+	  if (tid<nt0)
+          sdata[tid] = data[tid0 + tid+ NT*bid];
+
+      sdata[tid + nt0] = data[tid0 + tid + nt0 + NT*bid];
+	  __syncthreads();
+
+	  x = 0.0f;
+      for(nid=0;nid<Nrank;nid++){
+          y = 0.0f;
+		  #pragma unroll 4
+          for(i=0;i<nt0;i++)
+              y    += sW[i + nid*nt0] * sdata[i+tid];
+
+           x += y*y;
+      }
+      conv_sig[tid0  + tid + NT*bid]   = sqrt(x);
+
+      tid0+=Nthreads;
+      __syncthreads();
+  }
+}
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void  computeProjections(const double *Params, const float *dataraw,
+        const int *iC, const int *st, const int *id, const float *W, float *feat){
+
+    float x;
+    int tidx, nt0min, tidy, my_chan, this_chan, tid, bid, nt0, NchanNear, j, t, NT, NrankPC;
+    volatile __shared__ float sW[nt0max*NrankMax], sD[nt0max*NchanMax];
+
+    NT 		= (int) Params[0];
+    NchanNear = (int) Params[2];
+    nt0       = (int) Params[3];
+    NrankPC  = (int) Params[6];
+    nt0min    = (int) Params[4];
+
+    tidx = threadIdx.x;
+    tidy = threadIdx.y;
+    bid = blockIdx.x;
+
+    // move wPCA to shared memory
+    while (tidx<nt0){
+        sW[tidx + tidy*nt0] = W[tidx + tidy*nt0];
+        tidx+=blockDim.x;
+    }
+    tidx = threadIdx.x;
+
+    tid = tidx + tidy*blockDim.x;
+    // move raw data to shared memory
+    while (tid<nt0){
+        my_chan = id[bid];
+        for (j=0;j<NchanNear;j++){
+            this_chan = iC[j + NchanNear*my_chan];
+            sD[tid + nt0*j] = dataraw[tid + st[bid]+nt0min-1 + NT * this_chan];
+        }
+        tid+=blockDim.x*blockDim.y;
+    }
+    __syncthreads();
+
+    x = 0.0f;
+    for (t=0;t<nt0;t++)
+        x += sD[t + nt0*tidx] * sW[t + nt0*tidy];
+
+    feat[tidy + tidx*NrankPC + NrankPC*NchanNear*bid] = x;
+
+    }
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void maxChannels(const double *Params, const float *dataraw, const float *data,
+	const int *iC, int *st, int *id, int *counter){
+
+  int nt0, indx, tid, tid0, i, bid, NT, Nchan, NchanNear,j,iChan, nt0min;
+  double Cf, d;
+  float spkTh;
+  bool flag;
+
+  NT 		= (int) Params[0];
+  Nchan     = (int) Params[1];
+  NchanNear = (int) Params[2];
+  nt0       = (int) Params[3];
+  nt0min    = (int) Params[4];
+  spkTh    = (float) Params[5];
+
+  tid 		= threadIdx.x;
+  bid 		= blockIdx.x;
+
+  tid0 = tid + bid * blockDim.x;
+  while (tid0<NT-nt0-nt0min){
+      for (i=0; i<Nchan;i++){
+          iChan = iC[0 + NchanNear * i];
+          Cf    = (double) data[tid0 + NT * iChan];
+          flag = true;
+
+          for(j=1; j<NchanNear; j++){
+              iChan = iC[j+ NchanNear * i];
+              if (data[tid0 + NT * iChan] > Cf){
+                flag = false;
+                break;
+              }
+          }
+
+          if (flag){
+              iChan = iC[NchanNear * i];
+              if (Cf>spkTh){
+                  d = (double) dataraw[tid0+nt0min-1 + NT*iChan]; //
+                  if (d > Cf-1e-6){
+                      // this is a hit, atomicAdd and return spikes
+                      indx = atomicAdd(&counter[0], 1);
+                      if (indx<maxFR){
+                          st[indx] = tid0;
+                          id[indx] = iChan;
+                      }
+                  }
+              }
+          }
+      }
+      tid0 += blockDim.x * gridDim.x;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+__global__ void	max1D(const double *Params, const float *data, float *conv_sig){
+
+    volatile __shared__ float  sdata[Nthreads+81];
+    float y, spkTh;
+    int tid, tid0, bid, i, NT, nt0;
+
+    NT 		= (int) Params[0];
+    nt0       = (int) Params[3];
+    spkTh    = (float) Params[5];
+    tid 		= threadIdx.x;
+    bid 		= blockIdx.x;
+
+    tid0 = 0;
+    while (tid0<NT-Nthreads-nt0+1){
+        if (tid<nt0)
+            sdata[tid]   = data[tid0 + tid + NT*bid];
+        sdata[tid + nt0] = data[nt0+tid0 + tid+ NT*bid];
+        __syncthreads();
+
+        y = 0.0f;
+        #pragma unroll 4
+        for(i=0;i<nt0;i++)
+            y    = max(y, sdata[tid+i]);
+
+        if (y>spkTh)
+            conv_sig[tid0  + tid + NT*bid]   = y;
+
+        tid0+=Nthreads;
+        __syncthreads();
+    }
+}

--- a/pykilosort/cuda/mexWtW2.cu
+++ b/pykilosort/cuda/mexWtW2.cu
@@ -1,0 +1,54 @@
+const int nblock = 32;
+//////////////////////////////////////////////////////////////////////////////////////////
+
+__global__ void	crossFilter(const double *Params, const float *W1, const float *W2,
+        const float *UtU, float *WtW){
+  __shared__ float shW1[nblock*81], shW2[nblock*81];
+
+  float x;
+  int nt0, tidx, tidy , bidx, bidy, i, Nfilt, t, tid1, tid2;
+
+  tidx 		= threadIdx.x;
+  tidy 		= threadIdx.y;
+  bidx 		= blockIdx.x;
+  bidy 		= blockIdx.y;
+
+  Nfilt     = (int) Params[1];
+  nt0       = (int) Params[9];
+
+  tid1 = tidx + bidx*nblock;
+
+  tid2 = tidy + bidx*nblock;
+  if (tid2<Nfilt){
+      while(tidx<nt0){
+          shW1[tidx + tidy * nt0] = W1[tidx + tid2 * nt0];
+          tidx+= nblock;
+      }
+  }
+  tidx 		= threadIdx.x;
+  tid2      = tidy + bidy*nblock;
+  if (tid2<Nfilt){
+      while(tidx<nt0){
+          shW2[tidx + tidy * nt0] = W2[tidx + tid2 * nt0];
+          tidx+= nblock;
+      }
+  }
+  tidx 		= threadIdx.x;
+
+  __syncthreads();
+
+  if (tid2<Nfilt && tid1<Nfilt){
+      for(i=0;i<2*nt0-1;i++){
+          x = 0.0f;
+          if(i<nt0)
+              for(t=0;t<i+1;t++)
+                  x += shW1[t + nt0 * tidx] * shW2[t + (nt0-i-1) + nt0 * tidy];
+          else
+              for(t=i-nt0+1;t<nt0;t++)
+                  x += shW1[t + nt0 * tidx] * shW2[t + (nt0-i-1) + nt0 * tidy];
+
+          WtW[tid1 + tid2*Nfilt +  i*Nfilt*Nfilt] =
+                  x * UtU[tid1 + tid2*Nfilt];
+      }
+  }
+}

--- a/pykilosort/default_params.py
+++ b/pykilosort/default_params.py
@@ -1,0 +1,72 @@
+from math import ceil
+from .utils import Bunch
+
+default_params = Bunch()
+
+# sample rate
+default_params.fs = 30000.
+
+# frequency for high pass filtering (150)
+default_params.fshigh = 150.
+default_params.fslow = None
+
+# minimum firing rate on a "good" channel (0 to skip)
+default_params.minfr_goodchannels = 0.1
+
+# threshold on projections (like in Kilosort1, can be different for last pass like [10 4])
+default_params.Th = [10, 4]
+
+# how important is the amplitude penalty (like in Kilosort1, 0 means not used,
+# 10 is average, 50 is a lot)
+default_params.lam = 10
+
+# splitting a cluster at the end requires at least this much isolation for each sub-cluster (max=1)
+default_params.AUCsplit = 0.9
+
+# minimum spike rate (Hz), if a cluster falls below this for too long it gets removed
+default_params.minFR = 1. / 50
+
+# number of samples to average over (annealed from first to second value)
+default_params.momentum = [20, 400]
+
+# spatial constant in um for computing residual variance of spike
+default_params.sigmaMask = 30
+
+# threshold crossings for pre-clustering (in PCA projection space)
+default_params.ThPre = 8
+
+# danger, changing these settings can lead to fatal errors
+# options for determining PCs
+default_params.spkTh = -6  # spike threshold in standard deviations (-6)
+default_params.reorder = 1  # whether to reorder batches for drift correction.
+default_params.nskip = 25  # how many batches to skip for determining spike PCs
+
+# default_params.GPU = 1  # has to be 1, no CPU version yet, sorry
+# default_params.Nfilt = 1024 # max number of clusters
+default_params.nfilt_factor = 4  # max number of clusters per good channel (even temporary ones)
+default_params.ntbuff = 64  # samples of symmetrical buffer for whitening and spike detection
+# must be multiple of 32 + ntbuff. This is the batch size (try decreasing if out of memory).
+default_params.whiteningRange = 32  # number of channels to use for whitening each channel
+default_params.nSkipCov = 25  # compute whitening matrix from every N-th batch
+default_params.scaleproc = 200  # int16 scaling of whitened data
+default_params.nPCs = 3  # how many PCs to project the spikes into
+# default_params.useRAM = 0  # not yet available
+
+default_params.nt0 = 61
+default_params.nup = 10
+default_params.sig = 1
+default_params.gain = 1
+
+default_params.templateScaling = 20.0
+
+default_params.loc_range = [5, 4]
+default_params.long_range = [30, 6]
+
+
+def set_dependent_params(params):
+    """Add dependent parameters."""
+    # we need buffers on both sides for filtering
+    params.NT = params.get('NT', 64 * 1024 + params.ntbuff)
+    params.NTbuff = params.get('NTbuff', params.NT + 4 * params.ntbuff)
+    params.nt0min = params.get('nt0min', ceil(20 * params.nt0 / 61))
+    return params

--- a/pykilosort/event.py
+++ b/pykilosort/event.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+"""Simple event system."""
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+from contextlib import contextmanager
+import logging
+import re
+from functools import partial
+
+logger = logging.getLogger(__name__)
+
+
+#------------------------------------------------------------------------------
+# Event system
+#------------------------------------------------------------------------------
+
+class EventEmitter(object):
+    """Singleton class that emits events and accepts registered callbacks.
+
+    Example
+    -------
+
+    ```python
+    class MyClass(EventEmitter):
+        def f(self):
+            self.emit('my_event', 1, key=2)
+
+    o = MyClass()
+
+    # The following function will be called when `o.f()` is called.
+    @o.connect
+    def on_my_event(arg, key=None):
+        print(arg, key)
+
+    ```
+
+    """
+
+    def __init__(self):
+        self.reset()
+        self.is_silent = False
+
+    def set_silent(self, silent):
+        """Set whether to silence the events."""
+        self.is_silent = silent
+
+    def reset(self):
+        """Remove all registered callbacks."""
+        self._callbacks = []
+
+    def _get_on_name(self, func):
+        """Return `eventname` when the function name is `on_<eventname>()`."""
+        r = re.match("^on_(.+)$", func.__name__)
+        if r:
+            event = r.group(1)
+        else:
+            raise ValueError("The function name should be "
+                             "`on_<eventname>`().")
+        return event
+
+    @contextmanager
+    def silent(self):
+        """Prevent all callbacks to be called if events are raised
+        in the context manager.
+        """
+        self.is_silent = not(self.is_silent)
+        yield
+        self.is_silent = not(self.is_silent)
+
+    def connect(self, func=None, event=None, **kwargs):
+        """Register a callback function to a given event.
+
+        To register a callback function to the `spam` event, where `obj` is
+        an instance of a class deriving from `EventEmitter`:
+
+        ```python
+        @obj.connect
+        def on_spam(arg1, arg2):
+            pass
+        ```
+
+        This is called when `obj.emit('spam', arg1, arg2)` is called.
+
+        Several callback functions can be registered for a given event.
+
+        The registration order is conserved and may matter in applications.
+
+        """
+        if func is None:
+            return partial(self.connect, event=event, **kwargs)
+
+        # Get the event name from the function.
+        if event is None:
+            event = self._get_on_name(func)
+
+        # We register the callback function.
+        self._callbacks.append((event, func, kwargs))
+
+        return func
+
+    def unconnect(self, *items):
+        """Unconnect specified callback functions."""
+        self._callbacks = [
+            (event, f, kwargs)
+            for (event, f, kwargs) in self._callbacks
+            if f not in items]
+
+    def emit(self, event, *args, **kwargs):
+        """Call all callback functions registered with an event.
+
+        Any positional and keyword arguments can be passed here, and they will
+        be forwarded to the callback functions.
+
+        Return the list of callback return results.
+
+        """
+        if self.is_silent:
+            return
+        logger.log(
+            5, "Emit %s(%s, %s)", event,
+            ', '.join(map(str, args)), ', '.join('%s=%s' % (k, v) for k, v in kwargs.items()))
+        # Call the last callback if this is a single event.
+        single = kwargs.pop('single', None)
+        res = []
+        # Put `last=True` callbacks at the end.
+        callbacks = [c for c in self._callbacks if not c[-1].get('last', None)]
+        callbacks += [c for c in self._callbacks if c[-1].get('last', None)]
+        for e, f, k in callbacks:
+            if e == event:
+                f_name = getattr(f, '__qualname__', getattr(f, '__name__', str(f)))
+                logger.log(5, "Callback %s.", f_name)
+                res.append(f(*args, **kwargs))
+                if single:
+                    return res[-1]
+        return res
+
+
+#------------------------------------------------------------------------------
+# Global event system
+#------------------------------------------------------------------------------
+
+_EVENT = EventEmitter()
+
+emit = _EVENT.emit
+connect = _EVENT.connect
+unconnect = _EVENT.unconnect
+silent = _EVENT.silent
+set_silent = _EVENT.set_silent
+reset = _EVENT.reset

--- a/pykilosort/gui.py
+++ b/pykilosort/gui.py
@@ -1,0 +1,229 @@
+
+from pathlib import Path
+import logging
+from textwrap import dedent
+
+import click
+import numpy as np
+
+from phylib.io.model import load_raw_data
+from phylib.utils import Bunch, connect
+from phylib.utils.geometry import linear_positions
+
+from phy.apps import capture_exceptions
+from phy.cluster.views.trace import TraceImageView, select_traces
+from phy.cluster.views.probe import ProbeView
+from phy.gui import create_app, run_app, GUI, IPythonView, KeyValueWidget
+from phy.gui.qt import QSlider, Qt, QLabel, QScrollArea, QVBoxLayout, QWidget
+from phy.gui import Actions
+
+from .default_params import default_params
+from .main import run
+
+logger = logging.getLogger(__name__)
+
+
+# DEFAULT_PARAMS_PY = '''
+# dat_path = {dat_path}
+# n_channels_dat = {n_channels_dat}
+# dtype = "{dtype}"
+# offset = {offset}
+# sample_rate = {sample_rate}
+# '''
+
+
+class Parameters(QWidget):
+    pass
+
+
+class KilosortGUICreator(object):
+    def __init__(self, dat_path, **kwargs):
+        self.dat_path = Path(dat_path).resolve()
+        self.gui_name = 'PythonKilosortGUI'
+        self.__dict__.update(kwargs)
+        self.load_data()
+
+    def load_data(self):
+        # TODO: use EphysTraces
+        dat_path = self.dat_path
+        if dat_path.suffix == '.cbin':
+            data = load_raw_data(path=dat_path)
+            sample_rate = data.sample_rate
+            n_channels_dat = data.shape[1]
+        else:
+            sample_rate = float(self.sample_rate)
+            assert sample_rate > 0.
+
+            n_channels_dat = int(self.n_channels_dat)
+
+            dtype = np.dtype(self.dtype)
+            offset = int(self.offset or 0)
+            order = getattr(self, 'order', None)
+
+            # Memmap the raw data file.
+            data = load_raw_data(
+                path=dat_path,
+                n_channels_dat=n_channels_dat,
+                dtype=dtype,
+                offset=offset,
+                order=order,
+            )
+
+        # Parameters for the creation of params.py
+        self.n_channels_dat = n_channels_dat
+        self.offset = offset
+        self.dtype = dtype
+
+        self.data = data
+        self.duration = self.data.shape[0] / sample_rate
+
+    # def create_params(self):
+        # paramspy = DEFAULT_PARAMS_PY.format(
+        #     dat_path='["%s"]' % str(self.dat_path),
+        #     n_channels_dat=self.n_channels_dat,
+        #     offset=self.offset,
+        #     dtype=self.dtype,
+        #     sample_rate=self.sample_rate,
+        # )
+
+    def _run(self, stop_after=None):
+        # TODO: test
+        run(self.dat_path, self.probe, dir_path=self.dir_path, stop_after=stop_after)
+
+    def find_good_channels(self):
+        self._run('good_channels')
+        # TODO: update probe view
+
+    def preprocess(self):
+        self._run('preprocess')
+        # TODO: update trace view
+
+    def spike_sort(self):
+        self._run()
+        # TODO: create custom logging handler that redirectors to ipython view
+        # view.append_stream(...)
+
+    def create_actions(self, gui):
+        """Create the actions."""
+        self.actions = Actions(gui)
+        # self.actions.add(self.create_params, name="Create params.py", toolbar=True)
+        self.actions.add(self.find_good_channels, name="Find good channels", toolbar=True)
+        self.actions.add(self.preprocess, name="Preprocess", toolbar=True)
+        self.actions.add(self.spike_sort, name="Spike sort", toolbar=True)
+
+    def create_ipython_view(self, gui):
+        """Add the IPython view."""
+        view = IPythonView()
+        view.attach(gui)
+
+        view.inject(gui=gui, creator=self, data=self.data)
+
+        return view
+
+    def create_trace_view(self, gui):
+        """Add the trace view."""
+        gui._toolbar.addWidget(QLabel("Time selection: "))
+        time_slider = QSlider(Qt.Horizontal, gui)
+        time_slider.setRange(0, 100)
+        time_slider.setTracking(False)
+        gui._toolbar.addWidget(time_slider)
+        self.time_slider = time_slider
+
+        def _get_traces(interval):
+            return Bunch(data=select_traces(self.data, interval, sample_rate=self.sample_rate))
+
+        view = TraceImageView(
+            traces=_get_traces,
+            n_channels=self.n_channels_dat,
+            sample_rate=self.sample_rate,
+            duration=self.duration,
+            enable_threading=False,
+        )
+        view.attach(gui)
+
+        self.move_time_slider_to(view.time)
+
+        @time_slider.valueChanged.connect
+        def time_slider_changed():
+            view.go_to(float(time_slider.sliderPosition()) / 100 * self.duration)
+
+        @connect(sender=view)
+        def on_time_range_selected(sender, interval):
+            self.move_time_slider_to(.5 * (interval[0] + interval[1]))
+
+        return view
+
+    def move_time_slider_to(self, time):
+        """Move the time slider."""
+        self.time_slider.setSliderPosition(int(time / self.duration * 100))
+
+    def create_probe_view(self, gui):
+        """Add the view that shows the probe layout."""
+        channel_positions = linear_positions(self.n_channels_dat)
+        view = ProbeView(channel_positions)
+        view.attach(gui)
+        # TODO: update positions dynamically when the probe view changes
+        return view
+
+    def create_params_widget(self, gui):
+        """Create the widget that allows to enter parameters for KS2."""
+        widget = KeyValueWidget(gui)
+        for name, default in default_params.items():
+            # HACK: None default params in KS2 are floats
+            vtype = 'float' if default is None else None
+            widget.add_pair(name, default, vtype=vtype)
+        # Time interval (TODO: take it into account with EphysTraces).
+        widget.add_pair('time interval', [0.0, self.duration])
+        widget.add_pair('custom probe', dedent('''
+        # Python code that returns a probe variable which is a Bunch instance,
+        # with the following variables: NchanTOT, chanMap, xc, yc, kcoords.
+        ''').strip(), 'multiline')
+
+        scroll = QScrollArea()
+        scroll.setWidget(widget)
+        scroll.setWidgetResizable(True)
+        # scroll.show()
+
+        widget = Parameters(gui)
+        layout = QVBoxLayout(widget)
+        layout.addWidget(scroll)
+
+        gui.add_view(widget)
+        return widget
+
+    def create_gui(self):
+        """Create the spike sorting GUI."""
+
+        gui = GUI(name=self.gui_name, subtitle=self.dat_path.resolve(), enable_threading=False)
+        gui.has_save_action = False
+        gui.set_default_actions()
+        self.create_actions(gui)
+        self.create_params_widget(gui)
+        self.create_ipython_view(gui)
+        self.create_trace_view(gui)
+        self.create_probe_view(gui)
+
+        return gui
+
+
+# @phycli.command('kilosort')  # pragma: no cover
+@click.command()
+@click.argument('dat-path', type=click.Path(exists=True))
+@click.option('-s', '--sample-rate', type=float)
+@click.option('-d', '--dtype', type=str)
+@click.option('-n', '--n-channels', type=int)
+@click.option('-h', '--offset', type=int)
+@click.option('-f', '--fortran', type=bool, is_flag=True)
+# @click.pass_context
+def kilosort(dat_path, **kwargs):
+    """Launch the trace GUI on a raw data file."""
+    create_app()
+
+    with capture_exceptions():
+        kwargs['n_channels_dat'] = kwargs.pop('n_channels')
+        kwargs['order'] = 'F' if kwargs.pop('fortran', None) else None
+        creator = KilosortGUICreator(dat_path, **kwargs)
+        gui = creator.create_gui()
+        gui.show()
+        run_app()
+        gui.close()

--- a/pykilosort/learn.py
+++ b/pykilosort/learn.py
@@ -1,0 +1,1012 @@
+import logging
+from math import sqrt, ceil
+
+import numpy as np
+import cupy as cp
+from tqdm import tqdm
+
+from .cptools import svdecon, svdecon_cpu, median, free_gpu_memory, ones
+from .cluster import isolated_peaks_new, get_SpikeSample, getClosestChannels
+from .utils import Bunch, get_cuda, _extend, LargeArrayWriter
+
+logger = logging.getLogger(__name__)
+
+
+def extractTemplatesfromSnippets(proc=None, probe=None, params=None, Nbatch=None, nPCs=None):
+    # this function is very similar to extractPCfromSnippets.
+    # outputs not just the PC waveforms, but also the template "prototype",
+    # basically k-means clustering of 1D waveforms.
+
+    NT = params.NT
+    # skip every this many batches
+    nskip = params.nskip
+    nPCs = nPCs or params.nPCs
+    nt0min = params.nt0min
+    Nchan = probe.Nchan
+    batchstart = np.arange(0, NT * Nbatch + 1, NT).astype(np.int64)
+
+    k = 0
+    # preallocate matrix to hold 1D spike snippets
+    # dd = cp.zeros((params.nt0, int(5e4)), dtype=np.float32, order='F')
+    dds = []
+
+    for ibatch in tqdm(range(0, Nbatch, nskip), desc="Extracting templates"):
+        offset = Nchan * batchstart[ibatch]
+        dat = proc.flat[offset:offset + NT * Nchan].reshape((-1, Nchan), order='F')
+
+        # move data to GPU and scale it back to unit variance
+        dataRAW = cp.asarray(dat, dtype=np.float32) / params.scaleproc
+
+        # find isolated spikes from each batch
+        row, col, mu = isolated_peaks_new(dataRAW, params)
+
+        # for each peak, get the voltage snippet from that channel
+        c = get_SpikeSample(dataRAW, row, col, params)
+
+        # if k + c.shape[1] > dd.shape[1]:
+        #     dd = cp.pad(dd, (0, dd.shape[1]), mode='constant')
+
+        # dd[:, k:k + c.shape[1]] = c
+        dds.append(c)
+        k = k + c.shape[1]
+        if k > 1e5:
+            break
+
+    # discard empty samples
+    # dd = dd[:, :k]
+    dd = cp.asfortranarray(cp.concatenate(dds, axis=1).astype(np.float32))
+
+    # initialize the template clustering with random waveforms
+    uu = np.random.permutation(dd.shape[1])[:nPCs]
+    wTEMP = dd[:, uu]
+    wTEMP = wTEMP / cp.sum(wTEMP ** 2, axis=0) ** .5  # normalize them
+
+    for i in range(10):
+        # at each iteration, assign the waveform to its most correlated cluster
+        cc = cp.dot(wTEMP.T, dd)
+        imax = cp.argmax(cc, axis=0)
+        amax = cc[imax, np.arange(cc.shape[1])]
+        for j in range(nPCs):
+            # weighted average to get new cluster means
+            wTEMP[:, j] = cp.dot(dd[:, imax == j], amax[imax == j].T)
+        wTEMP = wTEMP / cp.sum(wTEMP ** 2, axis=0) ** .5  # unit normalize
+
+    # the PCs are just the left singular vectors of the waveforms
+    U, Sv, V = svdecon(dd)
+
+    # take as many as needed
+    wPCA = U[:, :nPCs]
+
+    # adjust the arbitrary sign of the first PC so its negativity is downward
+    wPCA[:, 0] = -wPCA[:, 0] * cp.sign(wPCA[nt0min, 0])
+
+    return wTEMP, wPCA
+
+
+def getKernels(params):
+    # this function makes upsampling kernels for the temporal components.
+    # those are used for interpolating the biggest negative peak,
+    # and aligning the template to that peak with sub-sample resolution
+    # needs nup, the interpolation factor (default = 10)
+    # also needs sig, the interpolation smoothness (default = 1)
+
+    nup = params.nup
+    sig = params.sig
+
+    nt0min = params.nt0min
+    nt0 = params.nt0
+
+    xs = cp.arange(1, nt0 + 1)
+    ys = cp.linspace(.5, nt0 + .5, nt0 * nup + 1)[:-1]
+
+    # these kernels are just standard kriging interpolators
+
+    # first compute distances between the sample coordinates
+    # for some reason, this seems to be circular, although the waveforms are not circular
+    # I think the reason had to do with some constant offsets in some channels?
+    d = cp.mod(xs[:, np.newaxis] - xs[np.newaxis, :] + nt0, nt0)
+    d = cp.minimum(d, nt0 - d)
+    # the kernel covariance uses a squared exponential of spatial scale sig
+    Kxx = cp.exp(-d ** 2 / sig ** 2)
+
+    # do the same for the kernel similarities between upsampled "test" timepoints and
+    # the original coordinates
+    d = cp.mod(ys[:, np.newaxis] - xs[np.newaxis, :] + nt0, nt0)
+    d = cp.minimum(d, nt0 - d)
+    Kyx = cp.exp(-d ** 2 / sig ** 2)
+
+    # the upsampling matrix is given by the following formula,
+    # with some light diagonal regularization of the matrix inversion
+    B = cp.dot(Kyx, cp.linalg.inv(Kxx + .01 * cp.eye(nt0)))
+    B = B.reshape((nup, nt0, nt0), order='F')
+
+    # A is just a slice through this upsampling matrix corresponding to the most negative point
+    # this is used to compute the biggest negative deflection (after upsampling)
+    A = cp.squeeze(B[:, nt0min - 1, :])
+    B = cp.transpose(B, [1, 2, 0])
+
+    return A.astype(np.float64), B.astype(np.float64)
+
+
+def getMeUtU(iU, iC, mask, Nnearest, Nchan):
+    # function [UtU, maskU, iList] = getMeUtU(iU, iC, mask, Nnearest, Nchan)
+    # this function determines if two templates share any channels
+    # iU are the channels that each template is assigned to, one main channel per template
+    # iC has as column K the list of neigboring channels for channel K
+    # mask are the weights assigned for the corresponding neighboring channels
+    # in iC (gaussian-decaying)
+
+    Nfilt = iU.size
+
+    # create a sparse matrix with ones if a channel K belongs to a template
+    U = np.zeros((Nchan, Nfilt), dtype=np.float32, order='F')
+
+    # use the template primary channel to obtain its neighboring channels from iC
+    ix = cp.asnumpy(iC[:, iU]) + np.arange(0, Nchan * Nfilt, Nchan).astype(np.int32)
+    # WARNING: transpose because the indexing assumes F ordering.
+    U.T.flat[ix] = 1  # use this as an awkward index into U
+
+    # if this is 0, the templates had not pair of channels in common
+    UtU = (cp.dot(U.T, U) > 0).astype(np.int32)
+
+    # we also return the masks for each template, picked from the corresponding mask of
+    # their primary channel
+    maskU = mask[:, iU]
+
+    # # sort template pairs in order of how many channels they share
+    # isort = cp.argsort(UtU, axis=0)[::-1]
+    # iList = isort[:Nnearest, :]  # take the Nnearest templates for each template
+
+    return UtU, maskU  # , iList
+
+
+def getMeWtW2(W, U0, Nnearest=None):
+    # this function compute the correlation between any two pairs of templates
+    # it relies on the fact that the W and U0 are unit normalized, so that the product of a
+    # template with itself is 1, as it should be if we're trying to calculate correlations
+
+    # takes input the temporal and spatial factors of the low-rank template, as
+    # well as the number of most similar template pairs desired to be output in
+    # iList
+
+    nt0, Nfilt, Nrank = W.shape
+    WtW = cp.zeros((Nfilt, Nfilt), dtype=np.float32, order='F')
+
+    # since the templates are factorized into orthonormal components, we can compute dot products
+    # one dimension at a time
+    for i in range(Nrank):
+        for j in range(Nrank):
+            #  this computes the spatial dot product
+            utu0 = cp.dot(U0[:, :, i].T, U0[:, :, j])
+            #  this computes the temporal dot product
+            wtw0 = cp.dot(W[:, :, i].T, W[:, :, j])
+
+            # the element-wise product of these is added to the matrix of correlatioons
+            WtW = WtW + wtw0 * utu0
+
+    # also return a list of most correlated template pairs
+    isort = cp.argsort(WtW, axis=0)[::-1]
+
+    if Nnearest:
+        # if we don't have enough templates yet, just wrap the indices around the range 1:Nfilt
+        iNear = cp.mod(cp.arange(Nnearest), Nfilt)
+        iList = isort[iNear, :]  # return the list of pairs for each template
+        return WtW, iList
+    else:
+        return WtW
+
+
+def mexGetSpikes2(Params, drez, wTEMP, iC):
+    code, constants = get_cuda('mexGetSpikes2')
+
+    NT = int(Params[0])
+    Nchan = int(Params[9])
+    nt0 = int(Params[4])
+    # Nnearest = int(Params[5])
+    Nrank = int(Params[14])
+
+    maxFR = constants.maxFR
+    Nthreads = constants.Nthreads
+
+    # tpB = (8, 2 * nt0 - 1)
+    # tpF = (16, Nnearest)
+    tpS = (nt0, 16)
+
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+    d_data = cp.asarray(drez, dtype=np.float32, order='F')
+    d_W = cp.asarray(wTEMP, dtype=np.float32, order='F')
+    d_iC = cp.asarray(iC, dtype=np.int32, order='F')
+
+    d_counter = cp.zeros(2, dtype=np.int32, order='F')
+    d_dout = cp.zeros((NT, Nchan), dtype=np.float32, order='F')
+    d_dfilt = cp.zeros((Nrank, NT, Nchan), dtype=np.float32, order='F')
+    d_err = cp.zeros(NT, dtype=np.float32, order='F')
+    d_kkmax = cp.zeros((NT, Nchan), dtype=np.int32, order='F')
+    d_kk = cp.zeros(NT, dtype=np.int32, order='F')
+    d_ftype = cp.zeros(NT, dtype=np.int32, order='F')
+    d_st = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_id = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_x = cp.zeros(maxFR, dtype=np.float32, order='F')
+    d_st1 = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_id1 = cp.zeros(maxFR, dtype=np.int32, order='F')
+
+    counter = np.zeros(2, dtype=np.int32, order='F')
+
+    # filter the data with the temporal templates
+    Conv1D = cp.RawKernel(code, 'Conv1D')
+    Conv1D((Nchan,), (Nthreads,), (d_Params, d_data, d_W, d_dfilt))
+
+    # sum each template across channels, square, take max
+    sumChannels = cp.RawKernel(code, 'sumChannels')
+    sumChannels((int(NT / Nthreads),), (Nthreads,), (d_Params, d_dfilt, d_dout, d_kkmax, d_iC))
+
+    # compute the best filter
+    bestFilter = cp.RawKernel(code, 'bestFilter')
+    bestFilter(
+        (int(NT / Nthreads),), (Nthreads,), (d_Params, d_dout, d_err, d_ftype, d_kkmax, d_kk))
+
+    # ignore peaks that are smaller than another nearby peak
+    cleanup_spikes = cp.RawKernel(code, 'cleanup_spikes')
+    cleanup_spikes(
+        (int(NT / Nthreads),), (Nthreads,), (d_Params, d_err, d_ftype, d_x, d_st, d_id, d_counter))
+
+    # ignore peaks that are smaller than another nearby peak
+    cleanup_heights = cp.RawKernel(code, 'cleanup_heights')
+    cleanup_heights(
+        (1 + int(maxFR // 32),), (32,), (d_Params, d_x, d_st, d_id, d_st1, d_id1, d_counter))
+
+    # add new spikes to 2nd counter
+    counter[0] = d_counter[1]
+    counter[0] = min(maxFR, counter[0])
+
+    d_WU = cp.zeros((nt0, Nchan, counter[0]), dtype=np.float32, order='F')
+    # d_WU1 = cp.zeros((nt0, Nchan, counter[0]), dtype=np.float32, order='F')
+
+    # update dWU here by adding back to subbed spikes
+    extract_snips = cp.RawKernel(code, 'extract_snips')
+    extract_snips((Nchan,), tpS, (d_Params, d_st1, d_id1, d_counter, d_data, d_WU))
+
+    # QUESTION: why a copy here??
+    # if counter[0] > 0:
+    #     d_WU1[...] = d_WU[...]
+
+    del (
+        d_ftype, d_kkmax, d_err, d_st, d_id, d_st1, d_x, d_kk, d_id1, d_counter,
+        d_Params, d_dfilt)
+    return d_WU, d_dout
+
+
+def mexSVDsmall2(Params, dWU, W, iC, iW, Ka, Kb):
+    code, constants = get_cuda('mexSVDsmall2')
+
+    Nthreads = constants.Nthreads
+
+    Nfilt = int(Params[1])
+    nt0 = int(Params[4])
+    Nrank = int(Params[6])
+    Nchan = int(Params[9])
+
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+
+    d_dWU = cp.asarray(dWU, dtype=np.float64, order='F')
+    d_iC = cp.asarray(iC, dtype=np.int32, order='F')
+    d_iW = cp.asarray(iW, dtype=np.int32, order='F')
+
+    d_A = cp.asarray(Ka, dtype=np.float64, order='F')
+    d_B = cp.asarray(Kb, dtype=np.float64, order='F')
+
+    d_U = cp.zeros((Nchan, Nfilt, Nrank), dtype=np.float64, order='F')
+    d_mu = cp.zeros(Nfilt, dtype=np.float64, order='F')
+
+    d_W = cp.asarray(W, dtype=np.float64, order='F')
+
+    d_wtw = cp.zeros((nt0, nt0, Nfilt), dtype=np.float64, order='F')
+    d_dWUb = cp.zeros((nt0, Nchan, Nfilt), dtype=np.float64, order='F')
+
+    tpS = (nt0, int(Nthreads // nt0))
+    tpK = (Nrank, int(Nthreads // Nrank))
+
+    blankdWU = cp.RawKernel(code, 'blankdWU')
+    blankdWU((Nfilt,), tpS, (d_Params, d_dWU, d_iC, d_iW, d_dWUb))
+
+    # compute dWU * dWU'
+    getwtw = cp.RawKernel(code, 'getwtw')
+    getwtw((Nfilt,), tpS, (d_Params, d_dWUb, d_wtw))
+
+    # get W by power svd iterations
+    getW = cp.RawKernel(code, 'getW')
+    getW((Nfilt,), (nt0,), (d_Params, d_wtw, d_W))
+
+    # compute U by W' * dWU
+    getU = cp.RawKernel(code, 'getU')
+    getU((Nfilt,), tpK, (d_Params, d_dWUb, d_W, d_U))
+
+    # normalize U, get S, get mu, renormalize W
+    reNormalize = cp.RawKernel(code, 'reNormalize')
+    reNormalize((Nfilt,), (nt0,), (d_Params, d_A, d_B, d_W, d_U, d_mu))
+
+    del d_wtw, d_Params, d_dWUb
+
+    return d_W, d_U, d_mu
+
+
+def mexMPnu8(Params, dataRAW, U, W, mu, iC, iW, UtU, iList, wPCA):
+    code, constants = get_cuda('mexMPnu8')
+    maxFR = int(constants.maxFR)
+    nmaxiter = int(constants.nmaxiter)
+    Nthreads = int(constants.Nthreads)
+
+    NT = int(Params[0])
+    Nfilt = int(Params[1])
+    nt0 = int(Params[4])
+    Nnearest = int(Params[5])
+    Nrank = int(Params[6])
+    NchanU = int(Params[10])
+    Nchan = int(Params[9])
+
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+
+    d_draw = cp.asarray(dataRAW, dtype=np.float32, order='F')
+    d_U = cp.asarray(U, dtype=np.float32, order='F')
+    d_W = cp.asarray(W, dtype=np.float32, order='F')
+    d_mu = cp.asarray(mu, dtype=np.float32, order='F')
+    d_iC = cp.asarray(iC, dtype=np.int32, order='F')
+    d_iW = cp.asarray(iW, dtype=np.int32, order='F')
+    d_UtU = cp.asarray(UtU, dtype=np.bool, order='F')
+    d_iList = cp.asarray(iList, dtype=np.int32, order='F')
+    d_wPCA = cp.asarray(wPCA, dtype=np.float32, order='F')
+
+    d_nsp = cp.zeros(Nfilt, dtype=np.int32, order='F')
+    d_dWU = cp.zeros((nt0, Nchan, Nfilt), dtype=np.float64, order='F')
+
+    d_dout = cp.zeros((2 * NT, Nfilt), dtype=np.float32, order='F')
+    d_data = cp.zeros((NT, Nfilt, Nrank), dtype=np.float32, order='F')
+    d_err = cp.zeros(NT, dtype=np.float32, order='F')
+    d_ftype = cp.zeros(NT, dtype=np.int32, order='F')
+    d_eloss = cp.zeros(NT, dtype=np.float32, order='F')
+    d_st = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_id = cp.zeros(maxFR, dtype=np.int32, order='F')
+    d_x = cp.zeros(maxFR, dtype=np.float32, order='F')
+    d_y = cp.zeros(maxFR, dtype=np.float32, order='F')
+    d_z = cp.zeros(maxFR, dtype=np.float32, order='F')
+
+    d_counter = cp.zeros(2, dtype=np.int32, order='F')
+    d_count = cp.zeros(nmaxiter, dtype=np.int32, order='F')
+    d_feat = cp.zeros((Nnearest, maxFR), dtype=np.float32, order='F')
+    d_featPC = cp.zeros((NchanU, Nrank, maxFR), dtype=np.float32, order='F')
+
+    counter = np.zeros(2, dtype=np.int32, order='F')
+
+    # tpB = (8, 2 * nt0 - 1)
+    tpF = (16, Nnearest)
+    tpS = (nt0, 16)
+    # tpW = (Nnearest, Nrank)
+    tpPC = (NchanU, Nrank)
+
+    # filter the data with the spatial templates
+    spaceFilter = cp.RawKernel(code, 'spaceFilter')
+    spaceFilter((Nfilt,), (Nthreads,), (d_Params, d_draw, d_U, d_iC, d_iW, d_data))
+
+    # filter the data with the temporal templates
+    timeFilter = cp.RawKernel(code, 'timeFilter')
+    timeFilter((Nfilt,), (Nthreads,), (d_Params, d_data, d_W, d_dout))
+
+    # compute the best filter
+    bestFilter = cp.RawKernel(code, 'bestFilter')
+    bestFilter(
+        (int(NT // Nthreads),), (Nthreads,), (d_Params, d_dout, d_mu, d_err, d_eloss, d_ftype))
+
+    # loop to find and subtract spikes
+    for k in range(int(Params[3])):
+        # ignore peaks that are smaller than another nearby peak
+        cleanup_spikes = cp.RawKernel(code, 'cleanup_spikes')
+        cleanup_spikes(
+            (int(NT // Nthreads),), (Nthreads,),
+            (d_Params, d_dout, d_mu, d_err, d_eloss,
+             d_ftype, d_st, d_id, d_x, d_y, d_z, d_counter))
+
+        # add new spikes to 2nd counter
+        counter[:] = cp.asnumpy(d_counter[:])
+        if counter[0] > maxFR:
+            counter[0] = maxFR
+            d_counter[0] = counter[0]
+
+        # extract template features before subtraction
+        if Params[12] > 1:
+            extractFEAT = cp.RawKernel(code, 'extractFEAT')
+            extractFEAT(
+                (64,), tpF, (d_Params, d_st, d_id, d_counter, d_dout, d_iList, d_mu, d_feat))
+
+        # subtract spikes from raw data here
+        subtract_spikes = cp.RawKernel(code, 'subtract_spikes')
+        subtract_spikes((Nfilt,), tpS, (d_Params, d_st, d_id, d_y, d_counter, d_draw, d_W, d_U))
+
+        # filter the data with the spatial templates
+        spaceFilterUpdate = cp.RawKernel(code, 'spaceFilterUpdate')
+        spaceFilterUpdate(
+            (Nfilt,), (2 * nt0 - 1,),
+            (d_Params, d_draw, d_U, d_UtU, d_iC, d_iW, d_data, d_st, d_id, d_counter))
+
+        # filter the data with the temporal templates
+        timeFilterUpdate = cp.RawKernel(code, 'timeFilterUpdate')
+        timeFilterUpdate(
+            (Nfilt,), (2 * nt0 - 1,),
+            (d_Params, d_data, d_W, d_UtU, d_dout, d_st, d_id, d_counter))
+
+        if counter[0] - counter[1] > 0:
+            bestFilterUpdate = cp.RawKernel(code, 'bestFilterUpdate')
+            bestFilterUpdate(
+                (counter[0] - counter[1],), (2 * nt0 - 1,),
+                (d_Params, d_dout, d_mu, d_err, d_eloss, d_ftype, d_st, d_id, d_counter))
+
+        d_count[k + 1] = d_counter[0]
+
+        # update 1st counter from 2nd counter
+        d_counter[1] = d_counter[0]
+
+    # compute PC features from reziduals + subtractions
+    if Params[12] > 0:
+        computePCfeatures = cp.RawKernel(code, 'computePCfeatures')
+        computePCfeatures(
+            (Nfilt,), tpPC,
+            (d_Params, d_counter, d_draw, d_st, d_id, d_y,
+             d_W, d_U, d_mu, d_iW, d_iC, d_wPCA, d_featPC))
+
+    # update dWU here by adding back to subbed spikes.
+    # additional parameter d_idx = array of time sorted indicies
+    average_snips = cp.RawKernel(code, 'average_snips')
+    average_snips(
+        (Nfilt,), tpS,
+        (d_Params, d_st, d_id, d_x, d_y, d_counter, d_draw, d_W, d_U, d_dWU, d_nsp, d_mu, d_z))
+
+    if counter[0] < maxFR:
+        minSize = counter[0]
+    else:
+        minSize = maxFR
+
+    del d_counter, d_Params, d_ftype, d_err, d_eloss, d_z, d_dout, d_data
+
+    return (
+        d_st[:minSize], d_id[:minSize], d_y[:minSize], d_feat[..., :minSize],
+        d_dWU, d_draw, d_nsp, d_featPC[..., :minSize], d_x[:minSize])
+
+
+def mexWtW2(Params, W1, W2, UtU):
+    code, constants = get_cuda('mexWtW2')
+
+    nblock = constants.nblock
+
+    Nfilt = int(Params[1])
+    nt0 = int(Params[9])
+
+    d_Params = cp.asarray(Params, dtype=np.float64, order='F')
+
+    d_W1 = cp.asarray(W1, dtype=np.float32, order='F')
+    d_W2 = cp.asarray(W2, dtype=np.float32, order='F')
+    d_UtU = cp.asarray(UtU, dtype=np.float32, order='F')
+
+    d_WtW = cp.zeros((Nfilt, Nfilt, 2 * nt0 - 1), dtype=np.float32, order='F')
+
+    grid = (1 + int(Nfilt // nblock), 1 + int(Nfilt // nblock))
+    block = (nblock, nblock)
+
+    crossFilter = cp.RawKernel(code, 'crossFilter')
+    crossFilter(grid, block, (d_Params, d_W1, d_W2, d_UtU, d_WtW))
+
+    del d_Params, d_W1, d_W2, d_UtU
+
+    return d_WtW
+
+
+def getMeWtW(W, U0, Nnearest=None):
+    # this function computes correlation between templates at ALL timelags from each other
+    # takes the max over timelags to obtain a similarity score
+    # also returns lists of most similar templates to each template
+    # takes as input the low-rank factorization of templates (W for time and U0
+    # for space)
+
+    # W is timesamples (default = 61 ), by number of templates, by rank (default = 3)
+    nt0, Nfilt, Nrank = W.shape
+
+    Params = [1, Nfilt, 0, 0, 0, 0, 0, 0, 0, nt0]
+
+    # initialize correlation matrix for all timelags
+    WtW = cp.zeros((Nfilt, Nfilt, 2 * nt0 - 1), dtype=np.float32, order='F')
+    for i in range(Nrank):
+        for j in range(Nrank):
+            # the dot product factorizes into separable products for each spatio-temporal component
+            utu0 = cp.dot(U0[:, :, i].T, U0[:, :, j])  # spatial products
+            # temporal convolutions get multiplied wit hthe spatial products
+            wtw0 = mexWtW2(Params, W[:, :, i], W[:, :, j], utu0)
+            # add it to the full correlation array
+            WtW = WtW + wtw0
+
+    # the maximum across timelags accounts for sample alignment mismatch
+    cc = cp.max(WtW, axis=2)
+
+    if Nnearest:
+        isort = cp.argsort(cc, axis=0)[::-1]
+        # if we don't have enough templates yet, just wrap the indices around the range 1:Nfilt
+        iNear = cp.mod(cp.arange(Nnearest), Nfilt)
+        iList = isort[iNear, :]  # return the list of pairs for each template
+        return WtW, iList
+    else:
+        return WtW
+
+
+def triageTemplates2(params, iW, C2C, W, U, dWU, mu, nsp, ndrop):
+
+    # This function checks if some templates should be dropped
+    # either because they are very similar to another template,
+    # or because they are not catching any spikes, (low mean firing rate).
+    # Takes as inputs almost all the information that determines templates, and
+    # outputs the same variables back after removing some clusters.
+
+    # this is the firing rate threshold
+    m0 = params.minFR * params.NT / params.fs
+    idrop = nsp < m0  # drop any templates with firing rate below this
+
+    # remove those templates everywhere
+    W = W[:, ~idrop, :]
+    U = U[:, ~idrop, :]
+    dWU = dWU[:, :, ~idrop]
+    mu = mu[~idrop]
+    nsp = nsp[~idrop]
+    # keep track of how many templates have been removed this way
+    ndrop[0] = .9 * ndrop[0] + .1 * idrop.sum()
+
+    # compute pairwise correlations between templates
+    cc = getMeWtW2(W, U, None)
+    cc = cc - cp.diag(cp.diag(cc))  # exclude the diagonal
+
+    sd = sqrt(10)  # this is hard-coded here
+
+    # compute a score for the separation of the means
+    r0 = 4 * sd / cp.abs(mu[:, np.newaxis] - mu[np.newaxis, :])
+    # determine which template has more spikes (that one survives)
+    rdir = (nsp[:, np.newaxis] - nsp[np.newaxis, :]) < 0
+    # for each pair of template, score their similarity by their template correlation,
+    # and amplitude separation
+    ipair = (cc > 0.9) & (r0 > 1) & rdir
+    # for each template, find its most similar other template
+    amax = cp.max(ipair, axis=1)
+    # if this score is 1, then all the criteria have bene met for dropping this template
+    idrop = amax > 0
+
+    # remove these templates everywhere like before
+    W = W[:, ~idrop, :]
+    U = U[:, ~idrop, :]
+    dWU = dWU[:, :, ~idrop]
+    mu = mu[~idrop]
+    nsp = nsp[~idrop]
+    # keep track of how many templates have been removed this way
+    ndrop[1] = .9 * ndrop[1] + .1 * idrop.sum()
+
+    return W, U, dWU, mu, nsp, ndrop
+
+
+def learnAndSolve8b(ctx):
+    """This is the main optimization. Takes the longest time and uses the GPU heavily."""
+
+    Nbatch = ctx.intermediate.Nbatch
+    params = ctx.params
+    probe = ctx.probe
+    ir = ctx.intermediate
+    proc = ir.proc
+
+    iorig = ir.iorig
+
+    NrankPC = 6  # this one is the rank of the PCs, used to detect spikes with threshold crossings
+    Nrank = 3  # this one is the rank of the templates
+
+    wTEMP, wPCA = extractTemplatesfromSnippets(
+        proc=proc, probe=probe, params=params, Nbatch=Nbatch, nPCs=NrankPC)
+
+    # move these to the GPU
+    wPCA = cp.asarray(wPCA[:, :Nrank], dtype=np.float32, order='F')
+    wTEMP = cp.asarray(wTEMP, dtype=np.float32, order='F')
+    wPCAd = cp.asarray(wPCA, dtype=np.float64, order='F')  # convert to double for extra precision
+
+    nt0 = params.nt0
+    nt0min = params.nt0min
+    nBatches = Nbatch
+    NT = params.NT
+    Nfilt = params.Nfilt
+    Nchan = probe.Nchan
+
+    # two variables for the same thing? number of nearest channels to each primary channel
+    NchanNear = min(probe.Nchan, 32)
+    Nnearest = min(probe.Nchan, 32)
+
+    # decay of gaussian spatial mask centered on a channel
+    sigmaMask = params.sigmaMask
+
+    batchstart = list(range(0, NT * nBatches + 1, NT))
+
+    # find the closest NchanNear channels, and the masks for those channels
+    iC, mask, C2C = getClosestChannels(probe, sigmaMask, NchanNear)
+
+    # sorting order for the batches
+    isortbatches = iorig
+    nhalf = int(ceil(nBatches / 2)) - 1  # halfway point
+
+    # this batch order schedule goes through half of the data forward and backward during the model
+    # fitting and then goes through the data symmetrically-out from the center during the final
+    # pass
+    ischedule = np.concatenate(
+        (np.arange(nhalf, nBatches), np.arange(nBatches - 1, nhalf - 1, -1)))
+    i1 = np.arange(nhalf - 1, -1, -1)
+    i2 = np.arange(nhalf, nBatches)
+
+    irounds = np.concatenate((ischedule, i1, i2))
+
+    niter = irounds.size
+    if irounds[niter - nBatches - 1] != nhalf:
+        # this check is in here in case I do somehting weird when I try different schedules
+        raise ValueError('Mismatch between number of batches')
+
+    # these two flags are used to keep track of what stage of model fitting we're at
+    # flag_final = 0
+    flag_resort = 1
+
+    # this is the absolute temporal offset in seconds corresponding to the start of the
+    # spike sorted time segment
+    t0 = 0  # ceil(params.trange(1) * ops.fs)
+
+    nInnerIter = 60  # this is for SVD for the power iteration
+
+    # schedule of learning rates for the model fitting part
+    # starts small and goes high, it corresponds approximately to the number of spikes
+    # from the past that were averaged to give rise to the current template
+    pmi = cp.exp(-1. / cp.linspace(params.momentum[0], params.momentum[1], niter - nBatches))
+
+    Nsum = min(Nchan, 7)  # how many channels to extend out the waveform in mexgetspikes
+    # lots of parameters passed into the CUDA scripts
+    Params = np.array([
+        NT, Nfilt, params.Th[0], nInnerIter, nt0, Nnearest,
+        Nrank, params.lam, pmi[0], Nchan, NchanNear, params.nt0min, 1,
+        Nsum, NrankPC, params.Th[0]], dtype=np.float64)
+
+    # W0 has to be ordered like this
+    W0 = cp.transpose(cp.atleast_3d(cp.asarray(wPCA, dtype=np.float64, order='F')), [0, 2, 1])
+
+    # initialize the list of channels each template lives on
+    iList = cp.zeros((Nnearest, Nfilt), dtype=np.int32, order='F')
+
+    # initialize average number of spikes per batch for each template
+    nsp = cp.zeros((0, 1), dtype=np.float64, order='F')
+
+    # this flag starts 0, is set to 1 later
+    Params[12] = 0
+
+    # kernels for subsample alignment
+    Ka, Kb = getKernels(params)
+
+    p1 = .95  # decay of nsp estimate in each batch
+
+    ntot = 0
+    # this keeps track of dropped templates for debugging purposes
+    ndrop = np.zeros(2, dtype=np.float32, order='F')
+
+    # this is the minimum firing rate that all templates must maintain, or be dropped
+    m0 = params.minFR * params.NT / params.fs
+
+    # allocate variables when switching to extraction phase
+    # this holds spike times, clusters and other info per spike
+    st3 = []  # cp.zeros((int(1e7), 5), dtype=np.float32, order='F')
+
+    # these ones store features per spike
+    # Nnearest is the number of nearest templates to store features for
+    fW = LargeArrayWriter(ctx.path('fW', ext='.dat'), dtype=np.float32, shape=(Nnearest, -1))
+    # NchanNear is the number of nearest channels to take PC features from
+    fWpc = LargeArrayWriter(
+        ctx.path('fWpc', ext='.dat'), dtype=np.float32, shape=(NchanNear, Nrank, -1))
+
+    for ibatch in tqdm(range(niter), desc="Optimizing templates"):
+        # korder is the index of the batch at this point in the schedule
+        korder = int(irounds[ibatch])
+        # k is the index of the batch in absolute terms
+        k = int(isortbatches[korder])
+        logger.debug("Batch %d/%d, %d templates.", ibatch, niter, Nfilt)
+
+        if ibatch > niter - nBatches - 1 and korder == nhalf:
+            # this is required to revert back to the template states in the middle of the
+            # batches
+            W, dWU = ir.W, ir.dWU
+            logger.debug('Reverted back to middle timepoint.')
+
+        if ibatch < niter - nBatches:
+            # obtained pm for this batch
+            Params[8] = float(pmi[ibatch])
+            pm = pmi[ibatch] * ones((Nfilt,), dtype=np.float64, order='F')
+
+        # loading a single batch (same as everywhere)
+        offset = Nchan * batchstart[k]
+        dat = proc.flat[offset:offset + NT * Nchan].reshape((-1, Nchan), order='F')
+        dataRAW = cp.asarray(dat, dtype=np.float32) / params.scaleproc
+
+        if ibatch == 0:
+            # only on the first batch, we first get a new set of spikes from the residuals,
+            # which in this case is the unmodified data because we start with no templates
+            # CUDA function to get spatiotemporal clips from spike detections
+            dWU, cmap = mexGetSpikes2(Params, dataRAW, wTEMP, iC)
+
+            dWU = cp.asarray(dWU, dtype=np.float64, order='F')
+
+            # project these into the wPCA waveforms
+            dWU = cp.reshape(
+                cp.dot(wPCAd, cp.dot(wPCAd.T, dWU.reshape((dWU.shape[0], -1), order='F'))),
+                dWU.shape, order='F')
+
+            # initialize the low-rank decomposition with standard waves
+            W = W0[:, cp.ones(dWU.shape[2], dtype=np.int32), :]
+            Nfilt = W.shape[1]  # update the number of filters/templates
+            # initialize the number of spikes for new templates with the minimum allowed value,
+            # so it doesn't get thrown back out right away
+            nsp = _extend(nsp, 0, Nfilt, m0)
+            Params[1] = Nfilt  # update in the CUDA parameters
+
+        if flag_resort:
+            # this is a flag to resort the order of the templates according to best peak
+            # channel
+            # this is important in order to have cohesive memory requests from the GPU RAM
+            # max channel (either positive or negative peak)
+            iW = cp.argmax(cp.abs(dWU[nt0min - 1, :, :]), axis=0)
+            # iW = int32(squeeze(iW))
+
+            isort = cp.argsort(iW)  # sort by max abs channel
+            iW = iW[isort]
+            W = W[:, isort, :]  # user ordering to resort all the other template variables
+            dWU = dWU[:, :, isort]
+            nsp = nsp[isort]
+
+        # decompose dWU by svd of time and space (via covariance matrix of 61 by 61 samples)
+        # this uses a "warm start" by remembering the W from the previous iteration
+        W, U, mu = mexSVDsmall2(Params, dWU, W, iC, iW, Ka, Kb)
+
+        # UtU is the gram matrix of the spatial components of the low-rank SVDs
+        # it tells us which pairs of templates are likely to "interfere" with each other
+        # such as when we subtract off a template
+        # this needs to change (but I don't know why!)
+        UtU, maskU = getMeUtU(iW, iC, mask, Nnearest, Nchan)
+
+        # main CUDA function in the whole codebase. does the iterative template matching
+        # based on the current templates, gets features for these templates if requested
+        # (featW, featPC),
+        # gets scores for the template fits to each spike (vexp), outputs the average of
+        # waveforms assigned to each cluster (dWU0),
+        # and probably a few more things I forget about
+        st0, id0, x0, featW, dWU0, drez, nsp0, featPC, vexp = mexMPnu8(
+            Params, dataRAW, U, W, mu, iC, iW, UtU, iList, wPCA)
+
+        logger.debug("%d spikes.", x0.size)
+
+        # Sometimes nsp can get transposed (think this has to do with it being
+        # a single element in one iteration, to which elements are added
+        # nsp, nsp0, and pm must all be row vectors (Nfilt x 1), so force nsp
+        # to be a row vector.
+        # nsp = cp.atleast_2d(nsp)
+        # nsprow, nspcol = nsp.shape
+        # if nsprow < nspcol:
+        #     nsp = nsp.T
+        nsp = nsp.squeeze()
+
+        # updates the templates as a running average weighted by recency
+        # since some clusters have different number of spikes, we need to apply the
+        # exp(pm) factor several times, and fexp is the resulting update factor
+        # for each template
+        fexp = np.exp(nsp0 * cp.log(pm[:Nfilt]))
+        fexp = cp.reshape(fexp, (1, 1, -1), order='F')
+        dWU = dWU * fexp + (1 - fexp) * (dWU0 / cp.reshape(
+            cp.maximum(1, nsp0), (1, 1, -1), order='F'))
+
+        # nsp just gets updated according to the fixed factor p1
+        nsp = nsp * p1 + (1 - p1) * nsp0
+
+        if ibatch == niter - nBatches - 1:
+            # if we reached this point, we need to disable secondary template updates
+            # like dropping, and adding new templates. We need to memorize the state of the
+            # templates at this timepoint, and set the processing mode to "extraction and
+            # tracking"
+
+            flag_resort = 0  # no need to resort templates by channel any more
+            # flag_final = 1  # this is the "final" pass
+
+            # final clean up, triage templates one last time
+            W, U, dWU, mu, nsp, ndrop = triageTemplates2(
+                params, iW, C2C, W, U, dWU, mu, nsp, ndrop)
+
+            # final number of templates
+            Nfilt = W.shape[1]
+            Params[1] = Nfilt
+
+            # final covariance matrix between all templates
+            WtW, iList = getMeWtW(W, U, Nnearest)
+
+            # iW is the final channel assigned to each template
+            iW = cp.argmax(cp.abs(dWU[nt0min - 1, :, :]), axis=0)
+
+            # extract ALL features on the last pass
+            Params[12] = 2  # this is a flag to output features (PC and template features)
+
+            # different threshold on last pass?
+            Params[2] = params.Th[-1]  # usually the threshold is much lower on the last pass
+
+            # memorize the state of the templates
+            logger.debug("Memorized middle timepoint.")
+            ir.W, ir.dWU, ir.U, ir.mu = W, dWU, U, mu
+            ir.Wraw = cp.zeros(
+                (U.shape[0], W.shape[0], U.shape[1]), dtype=np.float64, order='F')
+            for n in range(U.shape[1]):
+                # temporarily use U rather Urot until I have a chance to test it
+                ir.Wraw[:, :, n] = mu[n] * cp.dot(U[:, n, :], W[:, n, :].T)
+
+        if ibatch < niter - nBatches - 1:
+            # during the main "learning" phase of fitting a model
+            if ibatch % 5 == 0:
+                # this drops templates based on spike rates and/or similarities to
+                # other templates
+                W, U, dWU, mu, nsp, ndrop = triageTemplates2(
+                    params, iW, C2C, W, U, dWU, mu, nsp, ndrop)
+
+            Nfilt = W.shape[1]  # update the number of filters
+            Params[1] = Nfilt
+
+            # this adds new templates if they are detected in the residual
+            dWU0, cmap = mexGetSpikes2(Params, drez, wTEMP, iC)
+
+            if dWU0.shape[2] > 0:
+                # new templates need to be integrated into the same format as all templates
+                # apply PCA for smoothing purposes
+                dWU0 = cp.reshape(cp.dot(wPCAd, cp.dot(
+                    wPCAd.T, dWU0.reshape(
+                        (dWU0.shape[0], dWU0.shape[1] * dWU0.shape[2]), order='F'))),
+                    dWU0.shape, order='F')
+                dWU = cp.concatenate((dWU, dWU0), axis=2)
+
+                m = dWU0.shape[2]
+                # initialize temporal components of waveforms
+                W = _extend(W, Nfilt, Nfilt + m, W0[:, cp.ones(m, dtype=np.int32), :], axis=1)
+
+                # initialize the number of spikes with the minimum allowed
+                nsp = _extend(nsp, Nfilt, Nfilt + m, params.minFR * NT / params.fs)
+                # initialize the amplitude of this spike with a lowish number
+                mu = _extend(mu, Nfilt, Nfilt + m, 10)
+
+                # if the number of filters exceed the maximum allowed, clip it
+                Nfilt = min(params.Nfilt, W.shape[1])
+                Params[1] = Nfilt
+
+                W = W[:, :Nfilt, :]  # remove any new filters over the maximum allowed
+                dWU = dWU[:, :, :Nfilt]  # remove any new filters over the maximum allowed
+                nsp = nsp[:Nfilt]  # remove any new filters over the maximum allowed
+                mu = mu[:Nfilt]  # remove any new filters over the maximum allowed
+
+        if ibatch > niter - nBatches - 1:
+            # during the final extraction pass, this keeps track of all spikes and features
+
+            # we memorize the spatio-temporal decomposition of the waveforms at this batch
+            # this is currently only used in the GUI to provide an accurate reconstruction
+            # of the raw data at this time
+            ir.WA[..., k] = cp.asnumpy(W)
+            ir.UA[..., k] = cp.asnumpy(U)
+            ir.muA[..., k] = cp.asnumpy(mu)
+
+            # we carefully assign the correct absolute times to spikes found in this batch
+            ioffset = params.ntbuff - 1
+            if k == 0:
+                ioffset = 0  # the first batch is special (no pre-buffer)
+
+            toff = nt0min + t0 - ioffset + (NT - params.ntbuff) * k
+            st = toff + st0
+
+            st30 = np.c_[
+                cp.asnumpy(st),  # spike times
+                cp.asnumpy(id0),  # spike clusters (0-indexing)
+                cp.asnumpy(x0),  # template amplitudes
+                cp.asnumpy(vexp),  # residual variance of this spike
+                korder * np.ones(st.size),  # batch from which this spike was found
+            ]
+            # Check the number of spikes.
+            assert st30.shape[0] == featW.shape[1] == featPC.shape[2]
+            st3.append(st30)
+            fW.append(featW)
+            fWpc.append(featPC)
+
+            ntot = ntot + x0.size  # keeps track of total number of spikes so far
+
+        if ibatch == niter - nBatches - 1:
+            # these next three store the low-d template decompositions
+            ir.WA = np.zeros((nt0, Nfilt, Nrank, nBatches), dtype=np.float32, order='F')
+            ir.UA = np.zeros((Nchan, Nfilt, Nrank, nBatches), dtype=np.float32, order='F')
+            ir.muA = np.zeros((Nfilt, nBatches), dtype=np.float32, order='F')
+
+        if ibatch % 100 == 0:
+            # this is some of the relevant diagnostic information to be printed during training
+            logger.info(
+                ('%d / %d batches, %d units, nspks: %2.4f, mu: %2.4f, '
+                    'nst0: %d, merges: %2.4f, %2.4f'),
+                ibatch, niter, Nfilt, nsp.sum(), median(mu), st0.size, *ndrop)
+
+        free_gpu_memory()
+
+    # Close the large array writers and save the JSON metadata files to disk.
+    fW.close()
+    fWpc.close()
+
+    # just display the total number of spikes
+    logger.info("Found %d spikes.", ntot)
+
+    # Save results to the ctx.intermediate object.
+    ir.st3 = np.concatenate(st3, axis=0)
+
+    # the similarity score between templates is simply the correlation,
+    # taken as the max over several consecutive time delays
+    ir.simScore = cp.asnumpy(cp.max(WtW, axis=2))
+
+    # NOTE: these are now already saved by LargeArrayWriter
+    # fWa = np.concatenate(fW, axis=-1)
+    # fWpca = np.concatenate(fWpc, axis=-1)
+
+    # the template features are stored in cProj, like in Kilosort1
+    # ir.cProj = fWa.T
+    # the neihboring templates idnices are stored in iNeigh
+    ir.iNeigh = cp.asnumpy(iList)
+
+    #  permute the PC projections in the right order
+    # ir.cProjPC = np.transpose(fWpca, (2, 1, 0))
+    # iNeighPC keeps the indices of the channels corresponding to the PC features
+    ir.iNeighPC = cp.asnumpy(iC[:, iW])
+
+    # Number of spikes.
+    assert ir.st3.shape[0] == fW.shape[-1] == fWpc.shape[-1]
+
+    # this whole next block is just done to compress the compressed templates
+    # we separately svd the time components of each template, and the spatial components
+    # this also requires a careful decompression function, available somewhere in the GUI code
+    nKeep = min(Nchan * 3, 20)  # how many PCs to keep
+    W_a = np.zeros((nt0 * Nrank, nKeep, Nfilt), dtype=np.float32)
+    W_b = np.zeros((nBatches, nKeep, Nfilt), dtype=np.float32)
+    U_a = np.zeros((Nchan * Nrank, nKeep, Nfilt), dtype=np.float32)
+    U_b = np.zeros((nBatches, nKeep, Nfilt), dtype=np.float32)
+
+    for j in tqdm(range(Nfilt), desc='Compressing templates'):
+        # do this for every template separately
+        WA = np.reshape(ir.WA[:, j, ...], (-1, nBatches), order='F')
+        # svd on the GPU was faster for this, but the Python randomized CPU version
+        # might be faster still
+        # WA = gpuArray(WA)
+        A, B, C = svdecon_cpu(WA)
+        # W_a times W_b results in a reconstruction of the time components
+        W_a[:, :, j] = np.dot(A[:, :nKeep], B[:nKeep, :nKeep])
+        W_b[:, :, j] = C[:, :nKeep]
+
+        UA = np.reshape(ir.UA[:, j, ...], (-1, nBatches), order='F')
+        # UA = gpuArray(UA)
+        A, B, C = svdecon_cpu(UA)
+        # U_a times U_b results in a reconstruction of the time components
+        U_a[:, :, j] = np.dot(A[:, :nKeep], B[:nKeep, :nKeep])
+        U_b[:, :, j] = C[:, :nKeep]
+
+    logger.info('Finished compressing time-varying templates.')
+
+    return Bunch(
+        wPCA=wPCA[:, :Nrank],
+        wTEMP=wTEMP,
+        st3=ir.st3,
+        simScore=ir.simScore,
+        # cProj=ir.cProj,
+        # cProjPC=ir.cProjPC,
+        iNeigh=ir.iNeigh,
+        iNeighPC=ir.iNeighPC,
+        WA=ir.WA,
+        UA=ir.UA,
+        W=ir.W,
+        U=ir.U,
+        dWU=ir.dWU,
+        mu=ir.mu,
+        W_a=W_a,
+        W_b=W_b,
+        U_a=U_a,
+        U_b=U_b,
+    )

--- a/pykilosort/main.py
+++ b/pykilosort/main.py
@@ -1,0 +1,261 @@
+import logging
+from pathlib import Path
+from phylib.io.traces import get_ephys_reader
+
+from pprint import pprint
+import numpy as np
+
+from .preprocess import preprocess, get_good_channels, get_whitening_matrix, get_Nbatch
+from .cluster import clusterSingleBatches
+from .learn import learnAndSolve8b
+from .postprocess import find_merges, splitAllClusters, set_cutoff, rezToPhy
+from .utils import Bunch, Context, memmap_large_array, load_probe
+from .default_params import default_params, set_dependent_params
+
+logger = logging.getLogger(__name__)
+
+
+def default_probe(raw_data):
+    nc = raw_data.shape[1]
+    return Bunch(Nchan=nc, xc=np.zeros(nc), yc=np.arange(nc))
+
+
+def run(dat_path=None, probe=None, params=None, dir_path=None, stop_after=None, **kwargs):
+    """Launch KiloSort 2.
+
+    probe has the following attributes:
+    - xc
+    - yc
+    - kcoords
+    - Nchan
+
+    """
+
+    # Get or create the probe object.
+    if isinstance(probe, (str, Path)):
+        probe = load_probe(probe)
+
+    raw_data = get_ephys_reader(dat_path, **kwargs)
+    assert raw_data.ndim == 2
+
+    # Now, the initial raw data must be in C order, it will be converted to Fortran order
+    # in the proc file step, so as to use the existing CUDA kernels from MATLAB.
+    assert raw_data.shape[0] > raw_data.shape[1]  # nsamples > nchannels
+    n_samples, n_channels = raw_data.shape
+    logger.info("Loaded raw data with %d channels, %d samples.", n_channels, n_samples)
+
+    # Get probe.
+    probe = probe or default_probe(raw_data)
+    assert probe
+
+    # Get params.
+    user_params = params or {}
+    params = default_params.copy()
+    set_dependent_params(params)
+    params.update(user_params)
+    print('Parameters used:')
+    pprint(params)
+    assert params
+
+    # dir path
+    dir_path = dir_path or Path(dat_path).parent
+    assert dir_path, "Please provide a dir_path"
+    dir_path.mkdir(exist_ok=True, parents=True)
+    assert dir_path.exists()
+
+    # Create the context.
+    ctx_path = dir_path / '.kilosort' / raw_data.name
+    ctx = Context(ctx_path)
+    ctx.params = params
+    ctx.probe = probe
+    ctx.raw_data = raw_data
+
+    # Load the intermediate results to avoid recomputing things.
+    ctx.load()
+    ir = ctx.intermediate
+
+    ir.Nbatch = get_Nbatch(raw_data, params)
+
+    # -------------------------------------------------------------------------
+    # Find good channels.
+    # NOTE: now we use C order from loading up to the creation of the proc file, which is
+    # in Fortran order.
+    if params.minfr_goodchannels > 0:  # discard channels that have very few spikes
+        if 'igood' not in ir:
+            # determine bad channels
+            with ctx.time('good_channels'):
+                ir.igood = get_good_channels(raw_data=raw_data, probe=probe, params=params)
+            # Cache the result.
+            ctx.write(igood=ir.igood)
+        if stop_after == 'good_channels':
+            return ctx
+
+        # it's enough to remove bad channels from the channel map, which treats them
+        # as if they are dead
+        ir.igood = ir.igood.ravel()
+        probe.chanMap = probe.chanMap[ir.igood]
+        probe.xc = probe.xc[ir.igood]  # removes coordinates of bad channels
+        probe.yc = probe.yc[ir.igood]
+        probe.kcoords = probe.kcoords[ir.igood]
+    probe.Nchan = len(probe.chanMap)  # total number of good channels that we will spike sort
+    assert probe.Nchan > 0
+
+    # upper bound on the number of templates we can have
+    params.Nfilt = params.nfilt_factor * probe.Nchan
+
+    # -------------------------------------------------------------------------
+    # Find the whitening matrix.
+    if 'Wrot' not in ir:
+        # outputs a rotation matrix (Nchan by Nchan) which whitens the zero-timelag covariance
+        # of the data
+        with ctx.time('whitening_matrix'):
+            ir.Wrot = get_whitening_matrix(raw_data=raw_data, probe=probe, params=params)
+        # Cache the result.
+        ctx.write(Wrot=ir.Wrot)
+    if stop_after == 'whitening_matrix':
+        return ctx
+
+    # -------------------------------------------------------------------------
+    # Preprocess data to create proc.dat
+    ir.proc_path = ctx.path('proc', '.dat')
+    if not ir.proc_path.exists():
+        # Do not preprocess again if the proc.dat file already exists.
+        with ctx.time('preprocess'):
+            preprocess(ctx)
+    if stop_after == 'preprocess':
+        return ctx
+
+    # Open the proc file.
+    # NOTE: now we are always in Fortran order.
+    assert ir.proc_path.exists()
+    ir.proc = np.memmap(ir.proc_path, dtype=raw_data.dtype, mode='r', order='F')
+
+    # -------------------------------------------------------------------------
+    # Time-reordering as a function of drift.
+    #
+    # This function saves:
+    #
+    #       iorig, ccb0, ccbsort
+    #
+    if 'iorig' not in ir:
+        with ctx.time('reorder'):
+            out = clusterSingleBatches(ctx)
+        ctx.save(**out)
+    if stop_after == 'reorder':
+        return ctx
+
+    # -------------------------------------------------------------------------
+    # Main tracking and template matching algorithm.
+    #
+    # This function uses:
+    #
+    #         procfile
+    #         iorig
+    #
+    # This function saves:
+    #
+    #         wPCA, wTEMP
+    #         st3, simScore,
+    #         cProj, cProjPC,
+    #         iNeigh, iNeighPC,
+    #         WA, UA, W, U, dWU, mu,
+    #         W_a, W_b, U_a, U_b
+    #
+    if 'st3' not in ir:
+        with ctx.time('learn'):
+            out = learnAndSolve8b(ctx)
+        logger.info("%d spikes.", ir.st3.shape[0])
+        ctx.save(**out)
+    if stop_after == 'learn':
+        return ctx
+    # Special care for cProj and cProjPC which are memmapped .dat files.
+    ir.cProj = memmap_large_array(ctx.path('fW', ext='.dat')).T
+    ir.cProjPC = memmap_large_array(ctx.path('fWpc', ext='.dat')).T  # transpose
+
+    # -------------------------------------------------------------------------
+    # Final merges.
+    #
+    # This function uses:
+    #
+    #       st3, simScore
+    #
+    # This function saves:
+    #
+    #         st3_m,
+    #         R_CCG, Q_CCG, K_CCG [optional]
+    #
+    if 'st3_m' not in ir:
+        with ctx.time('merge'):
+            out = find_merges(ctx, True)
+        ctx.save(**out)
+    if stop_after == 'merge':
+        return ctx
+
+    # -------------------------------------------------------------------------
+    # Final splits.
+    #
+    # This function uses:
+    #
+    #       st3_m
+    #       W, dWU, cProjPC,
+    #       iNeigh, simScore
+    #       wPCA
+    #
+    # This function saves:
+    #
+    #       st3_s
+    #       W_s, U_s, mu_s, simScore_s
+    #       iNeigh_s, iNeighPC_s,
+    #       Wphy, iList, isplit
+    #
+    if 'st3_s1' not in ir:
+        # final splits by SVD
+        with ctx.time('split_1'):
+            out = splitAllClusters(ctx, True)
+        # Use a different name for both splitting steps.
+        out['st3_s1'] = out.pop('st3_s')
+        ctx.save(**out)
+    if stop_after == 'split_1':
+        return ctx
+
+    if 'st3_s0' not in ir:
+        # final splits by amplitudes
+        with ctx.time('split_2'):
+            out = splitAllClusters(ctx, False)
+        out['st3_s0'] = out.pop('st3_s')
+        ctx.save(**out)
+    if stop_after == 'split_2':
+        return ctx
+
+    # -------------------------------------------------------------------------
+    # Decide on cutoff.
+    #
+    # This function uses:
+    #
+    #       st3_s
+    #       dWU, cProj, cProjPC
+    #       wPCA
+    #
+    # This function saves:
+    #
+    #       st3_c, spikes_to_remove,
+    #       est_contam_rate, Ths, good
+    #
+    if 'st3_c' not in ir:
+        with ctx.time('cutoff'):
+            out = set_cutoff(ctx)
+        ctx.save(**out)
+    if stop_after == 'cutoff':
+        return ctx
+
+    logger.info("%d spikes after cutoff.", ir.st3_c.shape[0])
+    logger.info('Found %d good units.', np.sum(ir.good > 0))
+
+    # write to Phy
+    logger.info('Saving results to phy.')
+    with ctx.time('output'):
+        rezToPhy(ctx, dat_path=dat_path, output_dir=dir_path / 'output')
+
+    # Show timing information.
+    ctx.show_timer()
+    ctx.write(timer=ctx.timer)

--- a/pykilosort/postprocess.py
+++ b/pykilosort/postprocess.py
@@ -1,0 +1,1089 @@
+from math import ceil, erf, log as log_, sqrt
+import logging
+import os
+from os.path import join
+from pathlib import Path
+import shutil
+
+from tqdm import tqdm
+import numba
+import numpy as np
+import cupy as cp
+from cupyx.scipy.sparse import coo_matrix
+
+from .cptools import ones, svdecon, var, mean, free_gpu_memory
+from .cluster import getClosestChannels
+from .learn import getKernels, getMeWtW, mexSVDsmall2
+from .preprocess import my_conv2
+from .utils import Bunch, NpyWriter
+
+logger = logging.getLogger(__name__)
+
+
+def log(x):
+    if x == 0:
+        return -np.inf
+    return log_(x)
+
+
+def ccg_slow(st1, st2, nbins, tbin):
+    # this function efficiently computes the crosscorrelogram between two sets
+    # of spikes (st1, st2), with tbin length each, timelags =  plus/minus nbins
+    # and then estimates how refractory the cross-correlogram is, which can be used
+    # during merge decisions.
+
+    st1 = cp.sort(st1)  # makes sure spike trains are sorted in increasing order
+    st2 = cp.sort(st2)
+
+    dt = nbins * tbin
+
+    N1 = max(1, len(st1))
+    N2 = max(1, len(st2))
+    T = cp.concatenate((st1, st2)).max() - cp.concatenate((st1, st2)).min()
+
+    # we traverse both spike trains together, keeping track of the spikes in the first
+    # spike train that are within dt of spikes in the second spike train
+
+    ilow = 0  # lower bound index
+    ihigh = 0  # higher bound index
+    j = 0  # index of the considered spike
+
+    K = cp.zeros(2 * nbins + 1)
+
+    # (DEV_NOTES) the while loop below is far too slow as is
+
+    while j <= N2 - 1:  # traverse all spikes in the second spike train
+
+        while (ihigh <= N1 - 1) and (st1[ihigh] < st2[j] + dt):
+            ihigh += 1  # keep increasing higher bound until it's OUTSIDE of dt range
+
+        while (ilow <= N1 - 1) and (st1[ilow] <= st2[j] - dt):
+            ilow += 1  # keep increasing lower bound until it's INSIDE of dt range
+
+        if ilow > N1 - 1:
+            break  # break if we exhausted the spikes from the first spike train
+
+        if st1[ilow] > st2[j] + dt:
+            # if the lower bound is actually outside of dt range, means we overshot (there were no
+            # spikes in range)
+            # simply move on to next spike from second spike train
+            j += 1
+            continue
+
+        for k in range(ilow, ihigh):
+            # for all spikes within plus/minus dt range
+            ibin = cp.rint((st2[j] - st1[k]) / tbin).astype(int)  # convert ISI to integer
+
+            K[ibin + nbins] += 1
+
+        j += 1
+
+    irange1 = cp.concatenate((cp.arange(1, nbins // 2), cp.arange(3 * nbins // 2, 2 * nbins)))
+    irange2 = cp.arange(nbins - 50, nbins - 10)
+    irange3 = cp.arange(nbins + 11, nbins + 50)
+
+    # normalize the shoulders by what's expected from the mean firing rates
+    # a non-refractive poisson process should yield 1
+
+    Q00 = cp.sum(K[irange1]) / (len(irange1) * tbin * N1 * N2 / T)
+    # do the same for irange 2
+    Q01 = cp.sum(K[irange2]) / (len(irange2) * tbin * N1 * N2 / T)
+    # compare to the other shoulder
+    Q01 = max(Q01, cp.sum(K[irange3]) / (len(irange3) * tbin * N1 * N2 / T))
+
+    R00 = max(mean(K[irange2]), mean(K[irange3]))  # take the biggest shoulder
+    R00 = max(R00, mean(K[irange1]))  # compare this to the asymptotic shoulder
+
+    # test the probability that a central area in the autocorrelogram might be refractory
+    # test increasingly larger areas of the central CCG
+
+    a = K[nbins]
+    K[nbins] = 0
+
+    Qi = cp.zeros(10)
+    Ri = cp.zeros(10)
+
+    for i in range(1, 11):
+        irange = cp.arange(nbins - i, nbins + i + 1)  # for this central range of the CCG
+        # compute the normalised ratio as above. this should be 1 if there is no refractoriness
+        Qi0 = cp.sum(K[irange]) / (2 * i * tbin * N1 * N2 / T)
+        Qi[i - 1] = Qi0  # save the normalised probability
+
+        n = cp.sum(K[irange]) / 2
+        lam = R00 * i
+
+        # log(p) = log(lam) * n - lam - gammaln(n+1)
+
+        # this is tricky: we approximate the Poisson likelihood with a gaussian of equal mean and
+        # variance that allows us to integrate the probability that we would see <N spikes in the
+        # center of the cross-correlogram from a distribution with mean R00*i spikes
+
+        p = 1 / 2 * (1 + erf((n - lam) / cp.sqrt(2 * lam)))
+
+        Ri[i - 1] = p  # keep track of p for each bin size i
+
+    K[nbins] = a  # restore the center value of the cross-correlogram
+
+    return K, Qi, Q00, Q01, Ri
+
+
+# NOTE: we get a 50x time improvement with Numba jit of the existing function,
+# but we could probably achieve even more by improving the implementation
+@numba.jit(nopython=True, cache=False)
+def _ccg(st1, st2, nbins, tbin):
+    # this function efficiently computes the crosscorrelogram between two sets
+    # of spikes (st1, st2), with tbin length each, timelags =  plus/minus nbins
+    # and then estimates how refractory the cross-correlogram is, which can be used
+    # during merge decisions.
+
+    st1 = np.sort(st1)  # makes sure spike trains are sorted in increasing order
+    st2 = np.sort(st2)
+
+    dt = nbins * tbin
+
+    # Avoid divide by zero error.
+    T = max(1e-10, np.max(np.concatenate((st1, st2))) - np.min(np.concatenate((st1, st2))))
+    N1 = max(1, len(st1))
+    N2 = max(1, len(st2))
+
+    # we traverse both spike trains together, keeping track of the spikes in the first
+    # spike train that are within dt of spikes in the second spike train
+
+    ilow = 0  # lower bound index
+    ihigh = 0  # higher bound index
+    j = 0  # index of the considered spike
+
+    K = np.zeros(2 * nbins + 1)
+
+    # (DEV_NOTES) the while loop below is far too slow as is
+
+    while j <= N2 - 1:  # traverse all spikes in the second spike train
+
+        while (ihigh <= N1 - 1) and (st1[ihigh] < st2[j] + dt):
+            ihigh += 1  # keep increasing higher bound until it's OUTSIDE of dt range
+
+        while (ilow <= N1 - 1) and (st1[ilow] <= st2[j] - dt):
+            ilow += 1  # keep increasing lower bound until it's INSIDE of dt range
+
+        if ilow > N1 - 1:
+            break  # break if we exhausted the spikes from the first spike train
+
+        if st1[ilow] > st2[j] + dt:
+            # if the lower bound is actually outside of dt range, means we overshot (there were no
+            # spikes in range)
+            # simply move on to next spike from second spike train
+            j += 1
+            continue
+
+        for k in range(ilow, ihigh):
+            # for all spikes within plus/minus dt range
+            ibin = np.rint((st2[j] - st1[k]) / tbin)  # convert ISI to integer
+            ibin2 = np.asarray(ibin, dtype=np.int64)
+
+            K[ibin2 + nbins] += 1
+
+        j += 1
+
+    irange1 = np.concatenate((np.arange(1, nbins // 2), np.arange(3 * nbins // 2, 2 * nbins)))
+    irange2 = np.arange(nbins - 50, nbins - 10)
+    irange3 = np.arange(nbins + 11, nbins + 50)
+
+    # normalize the shoulders by what's expected from the mean firing rates
+    # a non-refractive poisson process should yield 1
+
+    Q00 = np.sum(K[irange1]) / (len(irange1) * tbin * N1 * N2 / T)
+    # do the same for irange 2
+    Q01 = np.sum(K[irange2]) / (len(irange2) * tbin * N1 * N2 / T)
+    # compare to the other shoulder
+    Q01 = max(Q01, np.sum(K[irange3]) / (len(irange3) * tbin * N1 * N2 / T))
+
+    R00 = max(np.mean(K[irange2]), np.mean(K[irange3]))  # take the biggest shoulder
+    R00 = max(R00, np.mean(K[irange1]))  # compare this to the asymptotic shoulder
+
+    # test the probability that a central area in the autocorrelogram might be refractory
+    # test increasingly larger areas of the central CCG
+
+    a = K[nbins]
+    K[nbins] = 0
+
+    Qi = np.zeros(10)
+    Ri = np.zeros(10)
+
+    for i in range(1, 11):
+        irange = np.arange(nbins - i, nbins + i + 1)  # for this central range of the CCG
+        # compute the normalised ratio as above. this should be 1 if there is no refractoriness
+        Qi0 = np.sum(K[irange]) / (2 * i * tbin * N1 * N2 / T)
+        Qi[i - 1] = Qi0  # save the normalised probability
+
+        n = np.sum(K[irange]) / 2
+        lam = R00 * i
+        if lam == 0:
+            p = np.nan
+        else:
+            # NOTE: make sure lam is not zero to avoid divide by zero error
+            # lam = max(1e-10, R00 * i)
+
+            # log(p) = log(lam) * n - lam - gammaln(n+1)
+
+            # this is tricky: we approximate the Poisson likelihood with a gaussian of equal mean
+            # and variance that allows us to integrate the probability that we would see <N spikes
+            # in the center of the cross-correlogram from a distribution with mean R00*i spikes
+
+            p = 1 / 2 * (1 + erf((n - lam) / sqrt(2 * lam)))
+
+        Ri[i - 1] = p  # keep track of p for each bin size i
+
+    K[nbins] = a  # restore the center value of the cross-correlogram
+
+    return K, Qi, Q00, Q01, Ri
+
+
+def ccg(st1, st2, nbins, tbin):
+    st1 = cp.asnumpy(st1)
+    st2 = cp.asnumpy(st2)
+    return _ccg(st1, st2, nbins, tbin)
+
+
+def clusterAverage(clu, spikeQuantity):
+    # get the average of some quantity across spikes in each cluster, given the
+    # quantity for each spike
+    #
+    # e.g.
+    # > clusterDepths = clusterAverage(clu, spikeDepths)
+    #
+    # clu and spikeQuantity must be vector, same size
+    #
+    # using a super-tricky algorithm for this - when you make a sparse
+    # array, the values of any duplicate indices are added. So this is the
+    # fastest way I know to make the sum of the entries of spikeQuantity for each of
+    # the unique entries of clu
+    _, cluInds, spikeCounts = cp.unique(clu, return_inverse=True, return_counts=True)
+
+    # summation
+    q = coo_matrix((spikeQuantity, (cluInds, cp.zeros(len(clu))))).toarray().flatten()
+
+    # had sums so dividing by spike counts gives the mean depth of each cluster
+    clusterQuantity = q / spikeCounts
+
+    return clusterQuantity
+
+
+def find_merges(ctx, flag):
+    # this function merges clusters based on template correlation
+    # however, a merge is veto-ed if refractory period violations are introduced
+
+    params = ctx.params
+    ir = ctx.intermediate
+
+    dt = 1. / 1000  # step size for CCG binning
+    nbins = 500  # number of bins used for cross-correlograms
+
+    # (DEV_NOTES) nbins is not a variable in Marius' code, I include it here to avoid
+    # unexplainable, hard-coded constants later
+
+    st3 = cp.asarray(ir.st3)
+    Xsim = cp.asarray(ir.simScore)  # this is the pairwise similarity score
+    Nk = Xsim.shape[0]
+    Xsim = Xsim - cp.diag(cp.diag(Xsim))
+
+    # sort by firing rate first
+    nspk = cp.zeros(Nk)
+    for j in range(Nk):
+        # determine total number of spikes in each neuron
+        nspk[j] = cp.sum(st3[:, 1] == j)
+
+    # we traverse the set of neurons in ascending order of firing rates
+    isort = cp.argsort(nspk)
+
+    logger.debug('Initialized spike counts.')
+
+    if not flag:
+        # if the flag is off, then no merges are performed
+        # this function is then just used to compute cross- and auto- correlograms
+        R_CCG = cp.inf * ones(Nk, order='F')
+        Q_CCG = cp.inf * ones(Nk, order='F')
+        K_CCG = cp.zeros((*Xsim.shape, 2 * nbins + 1), order='F')
+    else:
+        K_CCG = None
+        R_CCG = None
+        Q_CCG = None
+
+    for j in tqdm(range(Nk), desc='Finding merges'):
+        # find all spikes from this cluster
+        s1 = st3[:, 0][st3[:, 1] == isort[j]] / params.fs
+
+        if s1.size != nspk[isort[j]]:
+            # this is a check to make sure new clusters are combined correctly into bigger clusters
+            logger.warn('Lost track of spike counts.')
+
+        # sort all the pairs of this neuron, discarding any that have fewer spikes
+
+        uu = Xsim[isort[j], :] * (nspk > s1.size)
+        ix = cp.argsort(uu)[::-1]
+        ccsort = uu[ix]
+        ienu = int(np.nonzero(ccsort < .5)[0][0])
+
+        # ccsort = -cp.sort(-Xsim[isort[j]] * (nspk > len(s1)))  # sort in descending order
+        # ix = cp.argsort(-Xsim[isort[j]] * (nspk > len(s1)))
+
+        # if ccsort[len(ccsort) - 1] > 0.5:
+        #     ienu = len(ccsort)
+        # else:
+        #     ienu = cp.argmax(ccsort < 0.5)
+
+        # for all pairs above 0.5 correlation
+
+        for k in range(ienu):
+            # find the spikes of the pair
+            s2 = st3[:, 0][st3[:, 1] == ix[k]] / params.fs
+            # compute cross-correlograms, refractoriness scores (Qi and rir), and normalization
+            # for these scores
+            K, Qi, Q00, Q01, rir = ccg(s1, s2, nbins, dt)
+            # normalize the central cross-correlogram bin by its shoulders OR
+            # by its mean firing rate
+            Q = (Qi / max(Q00, Q01)).min()
+            # R is the estimated probability that any of the center bins are refractory,
+            # and kicks in when there are very few spikes
+            R = rir.min()
+
+            if flag:
+                if (Q < 0.2) and (R < 0.05):  # if both refractory criteria are met
+                    i = ix[k]
+                    # now merge j into i and move on
+                    # simply overwrite all the spikes of neuron j with i (i>j by construction)
+                    st3[:, 1][st3[:, 1] == isort[j]] = i
+                    nspk[i] = nspk[i] + nspk[isort[j]]  # update number of spikes for cluster i
+                    logger.debug(f'Merged {isort[j]} into {i}')
+                    # YOU REALLY SHOULD MAKE SURE THE PC CHANNELS MATCH HERE
+                    # break % if a pair is found, we don't need to keep going
+                    # (we'll revisit this cluster when we get to the merged cluster)
+                    break
+            else:
+                # sometimes we just want to get the refractory scores and CCG
+                R_CCG[isort[j], ix[k]] = R
+                Q_CCG[isort[j], ix[k]] = Q
+
+                K_CCG[isort[j], ix[k]] = K
+                K_CCG[ix[k], isort[j]] = K[::-1]
+
+    if not flag:
+        R_CCG = cp.minimum(R_CCG, R_CCG.T)  # symmetrize the scores
+        Q_CCG = cp.minimum(Q_CCG, Q_CCG.T)
+
+    return Bunch(
+        st3_m=st3,
+        K_CCG=K_CCG,
+        R_CCG=R_CCG,
+        Q_CCG=Q_CCG,
+    )
+
+
+def splitAllClusters(ctx, flag):
+    # I call this algorithm "bimodal pursuit"
+    # split clusters if they have bimodal projections
+    # the strategy is to maximize a bimodality score and find a single vector projection
+    # that maximizes it. If the distribution along that maximal projection crosses a
+    # bimodality threshold, then the cluster is split along that direction
+    # it only uses the PC features for each spike, stored in ir.cProjPC
+
+    params = ctx.params
+    probe = ctx.probe
+    ir = ctx.intermediate
+    Nchan = ctx.probe.Nchan
+
+    wPCA = cp.asarray(ir.wPCA)  # use PCA projections to reconstruct templates when we do splits
+    assert wPCA.shape[1] == 3
+
+    # Take intermediate arrays from context.
+    st3 = cp.asnumpy(ir.st3_m)
+    cProjPC = ir.cProjPC
+    dWU = ir.dWU
+
+    # For the following arrays that will be overwritten by this function, try to get
+    # it from a previous call to this function (as it is called twice), otherwise
+    # get it from before (without the _s suffix).
+    W = ir.get('W_s', ir.W)
+    simScore = ir.get('simScore_s', ir.simScore)
+    iNeigh = ir.get('iNeigh_s', ir.iNeigh)
+    iNeighPC = ir.get('iNeighPC_s', ir.iNeighPC)
+
+    # this is the threshold for splits, and is one of the main parameters users can change
+    ccsplit = params.AUCsplit
+
+    NchanNear = min(Nchan, 32)
+    Nnearest = min(Nchan, 32)
+    sigmaMask = params.sigmaMask
+
+    ik = -1
+    Nfilt = W.shape[1]
+    nsplits = 0
+
+    # determine what channels each template lives on
+    iC, mask, C2C = getClosestChannels(probe, sigmaMask, NchanNear)
+
+    # the waveforms must be aligned to this sample
+    nt0min = params.nt0min
+    # find the peak abs channel for each template
+    iW = np.argmax(np.abs((dWU[nt0min - 1, :, :])), axis=0)
+
+    # keep track of original cluster for each cluster. starts with all clusters being their
+    # own origin.
+    isplit = np.arange(Nfilt)
+    dt = 1. / 1000
+    nccg = 0
+
+    while ik < Nfilt:
+        if ik % 100 == 0:
+            # periodically write updates
+            logger.info(f'Found {nsplits} splits, checked {ik}/{Nfilt} clusters, nccg {nccg}')
+        ik += 1
+
+        isp = (st3[:, 1] == ik)  # get all spikes from this cluster
+        nSpikes = isp.sum()
+        logger.debug(f"Splitting template {ik}/{Nfilt} with {nSpikes} spikes.")
+        free_gpu_memory()
+
+        if nSpikes < 300:
+            # do not split if fewer than 300 spikes (we cannot estimate
+            # cross-correlograms accurately)
+            continue
+
+        ss = st3[isp, 0] / params.fs  # convert to seconds
+
+        clp0 = cProjPC[isp, :, :]  # get the PC projections for these spikes
+        clp0 = cp.asarray(clp0, dtype=cp.float32)  # upload to the GPU
+        clp0 = clp0.reshape((clp0.shape[0], -1), order='F')
+        m = mean(clp0, axis=0)
+        clp = clp0
+        clp -= m  # mean center them
+
+        isp = np.nonzero(isp)[0]
+
+        # (DEV_NOTES) Python flattens clp0 in C order rather than Fortran order so the
+        # flattened PC projections will be slightly different, however this is fixed when
+        # the projections are reformed later
+
+        # subtract a running average, because the projections are NOT drift corrected
+        clpc = my_conv2(clp, 250, 0)
+        clp -= clpc
+
+        # now use two different ways to initialize the bimodal direction
+        # the main script calls this function twice, and does both initializations
+
+        if flag:
+            u, s, v = svdecon(clp.T)
+            u, v = -u, -v  # change sign for consistency with MATLAB
+            w = u[:, 0]  # initialize with the top PC
+        else:
+            w = mean(clp0, axis=0)  # initialize with the mean of NOT drift-corrected trace
+            w = w / cp.sum(w ** 2) ** 0.5  # unit-normalize
+
+        # initial projections of waveform PCs onto 1D vector
+        x = cp.dot(clp, w)
+        s1 = var(x[x > mean(x)])  # initialize estimates of variance for the first
+        s2 = var(x[x < mean(x)])  # and second gaussian in the mixture of 1D gaussians
+
+        mu1 = mean(x[x > mean(x)])  # initialize the means as well
+        mu2 = mean(x[x < mean(x)])
+        # and the probability that a spike is assigned to the first Gaussian
+        p = mean(x > mean(x))
+
+        # initialize matrix of log probabilities that each spike is assigned to the first
+        # or second cluster
+        logp = cp.zeros((nSpikes, 2), order='F')
+
+        # do 50 pursuit iteration
+
+        logP = cp.zeros(50)  # used to monitor the cost function
+
+        for k in range(50):
+            # for each spike, estimate its probability to come from either Gaussian cluster
+            logp[:, 0] = -1. / 2 * log(s1) - ((x - mu1) ** 2) / (2 * s1) + log(p)
+            logp[:, 1] = -1. / 2 * log(s2) - ((x - mu2) ** 2) / (2 * s2) + log(1 - p)
+
+            lMax = logp.max(axis=1)
+            logp = logp - lMax[:, cp.newaxis]  # subtract the max for floating point accuracy
+            rs = cp.exp(logp)  # exponentiate the probabilities
+
+            pval = cp.log(cp.sum(rs, axis=1)) + lMax  # get the normalizer and add back the max
+            logP[k] = mean(pval)  # this is the cost function: we can monitor its increase
+
+            rs = rs / cp.sum(rs, axis=1)[:, cp.newaxis]  # normalize so that probabilities sum to 1
+
+            p = mean(rs[:, 0])  # mean probability to be assigned to Gaussian 1
+            # new estimate of mean of cluster 1 (weighted by "responsibilities")
+            mu1 = cp.dot(rs[:, 0], x) / cp.sum(rs[:, 0])
+            # new estimate of mean of cluster 2 (weighted by "responsibilities")
+            mu2 = cp.dot(rs[:, 1], x) / cp.sum(rs[:, 1])
+
+            s1 = cp.dot(rs[:, 0], (x - mu1) ** 2) / cp.sum(rs[:, 0])  # new estimates of variances
+            s2 = cp.dot(rs[:, 1], (x - mu2) ** 2) / cp.sum(rs[:, 1])
+
+            if (k >= 10) and (k % 2 == 0):
+                # starting at iteration 10, we start re-estimating the pursuit direction
+                # that is, given the Gaussian cluster assignments, and the mean and variances,
+                # we re-estimate w
+                # these equations follow from the model
+                StS = cp.matmul(
+                    clp.T, clp * (rs[:, 0] / s1 + rs[:, 1] / s2)[:, cp.newaxis]) / nSpikes
+                StMu = cp.dot(clp.T, rs[:, 0] * mu1 / s1 + rs[:, 1] * mu2 / s2) / nSpikes
+
+                # this is the new estimate of the best pursuit direction
+                w = cp.linalg.solve(StS.T, StMu)
+                w = w / cp.sum(w ** 2) ** 0.5  # which we unit normalize
+                x = cp.dot(clp, w)
+
+        # these spikes are assigned to cluster 1
+        ilow = rs[:, 0] > rs[:, 1]
+        # the mean probability of spikes assigned to cluster 1
+        plow = mean(rs[:, 0][ilow])
+        phigh = mean(rs[:, 1][~ilow])  # same for cluster 2
+        # the smallest cluster has this proportion of all spikes
+        nremove = min(mean(ilow), mean(~ilow))
+
+        # did this split fix the autocorrelograms?
+        # compute the cross-correlogram between spikes in the putative new clusters
+        ilow_cpu = cp.asnumpy(ilow)
+        K, Qi, Q00, Q01, rir = ccg(ss[ilow_cpu], ss[~ilow_cpu], 500, dt)
+        Q12 = (Qi / max(Q00, Q01)).min()  # refractoriness metric 1
+        R = rir.min()  # refractoriness metric 2
+
+        # if the CCG has a dip, don't do the split.
+        # These thresholds are consistent with the ones from merges.
+        if (Q12 < 0.25) and (R < 0.05):  # if both metrics are below threshold.
+            nccg += 1  # keep track of how many splits were voided by the CCG criterion
+            continue
+
+        # now decide if the split would result in waveforms that are too similar
+        # the reconstructed mean waveforms for putative cluster 1
+        # c1 = cp.matmul(wPCA, cp.reshape((mean(clp0[ilow, :], 0), 3, -1), order='F'))
+        c1 = cp.matmul(wPCA, mean(clp0[ilow, :], 0).reshape((3, -1), order='F'))
+        # the reconstructed mean waveforms for putative cluster 2
+        # c2 = cp.matmul(wPCA, cp.reshape((mean(clp0[~ilow, :], 0), 3, -1), order='F'))
+        c2 = cp.matmul(wPCA, mean(clp0[~ilow, :], 0).reshape((3, -1), order='F'))
+
+        cc = cp.corrcoef(c1.ravel(), c2.ravel())  # correlation of mean waveforms
+        n1 = sqrt(cp.sum(c1 ** 2))  # the amplitude estimate 1
+        n2 = sqrt(cp.sum(c2 ** 2))  # the amplitude estimate 2
+
+        r0 = 2 * abs((n1 - n2) / (n1 + n2))
+
+        # if the templates are correlated, and their amplitudes are similar, stop the split!!!
+
+        if (cc[0, 1] > 0.9) and (r0 < 0.2):
+            continue
+
+        # finaly criteria to continue with the split: if the split piece is more than 5% of all
+        # spikes, if the split piece is more than 300 spikes, and if the confidences for
+        # assigning spikes to # both clusters exceeds a preset criterion ccsplit
+        if (nremove > 0.05) and (min(plow, phigh) > ccsplit) and (
+                min(cp.sum(ilow), cp.sum(~ilow)) > 300):
+            # one cluster stays, one goes
+            Nfilt += 1
+
+            # the templates for the splits have been estimated from PC coefficients
+
+            # (DEV_NOTES) code below involves multiple CuPy arrays changing shape to accomodate
+            # the extra cluster, this could potentially be done more efficiently?
+
+            dWU = cp.concatenate((
+                cp.asarray(dWU), cp.zeros((*dWU.shape[:-1], 1), order='F')), axis=2)
+            dWU[:, iC[:, iW[ik]], Nfilt - 1] = c2
+            dWU[:, iC[:, iW[ik]], ik] = c1
+
+            # the temporal components are therefore just the PC waveforms
+            W = cp.asarray(W)
+            W = cp.concatenate((W, cp.transpose(cp.atleast_3d(wPCA), (0, 2, 1))), axis=1)
+            assert W.shape[1] == Nfilt
+
+            # copy the best channel from the original template
+            iW = cp.asarray(iW)
+            iW = cp.pad(iW, (0, (Nfilt - len(iW))), mode='constant')
+            iW[Nfilt - 1] = iW[ik]
+            assert iW.shape[0] == Nfilt
+
+            # copy the provenance index to keep track of splits
+            isplit = cp.asarray(isplit)
+            isplit = cp.pad(isplit, (0, (Nfilt - len(isplit))), mode='constant')
+            isplit[Nfilt - 1] = isplit[ik]
+            assert isplit.shape[0] == Nfilt
+
+            st3[isp[ilow_cpu], 1] = Nfilt - 1  # overwrite spike indices with the new index
+
+            # copy similarity scores from the original
+            simScore = cp.asarray(simScore)
+            simScore = cp.pad(
+                simScore, (0, (Nfilt - simScore.shape[0])), mode='constant')
+            simScore[:, Nfilt - 1] = simScore[:, ik]
+            simScore[Nfilt - 1, :] = simScore[ik, :]
+            # copy similarity scores from the original
+            simScore[ik, Nfilt - 1] = 1  # set the similarity with original to 1
+            simScore[Nfilt - 1, ik] = 1  # set the similarity with original to 1
+            assert simScore.shape == (Nfilt, Nfilt)
+
+            # copy neighbor template list from the original
+            iNeigh = cp.asarray(iNeigh)
+            iNeigh = cp.pad(
+                iNeigh, ((0, 0), (0, (Nfilt - iNeigh.shape[1]))), mode='constant')
+            iNeigh[:, Nfilt - 1] = iNeigh[:, ik]
+            assert iNeigh.shape[1] == Nfilt
+
+            # copy neighbor channel list from the original
+            iNeighPC = cp.asarray(iNeighPC)
+            iNeighPC = cp.pad(
+                iNeighPC, ((0, 0), (0, (Nfilt - iNeighPC.shape[1]))), mode='constant')
+            iNeighPC[:, Nfilt - 1] = iNeighPC[:, ik]
+            assert iNeighPC.shape[1] == Nfilt
+
+            # try this cluster again
+            # the cluster piece that stays at this index needs to be tested for splits again
+            # before proceeding
+            ik -= 1
+            # the piece that became a new cluster will be tested again when we get to the end
+            # of the list
+            nsplits += 1  # keep track of how many splits we did
+    #         pbar.update(ik)
+    # pbar.close()
+
+    logger.info(
+        f'Finished splitting. Found {nsplits} splits, checked '
+        f'{ik}/{Nfilt} clusters, nccg {nccg}')
+
+    Nfilt = W.shape[1]  # new number of templates
+    Nrank = 3
+    Nchan = probe.Nchan
+    Params = cp.array(
+        [0, Nfilt, 0, 0, W.shape[0], Nnearest, Nrank, 0, 0, Nchan, NchanNear, nt0min, 0],
+        dtype=cp.float64)  # make a new Params to pass on parameters to CUDA
+
+    # we need to re-estimate the spatial profiles
+
+    # we get the time upsampling kernels again
+    Ka, Kb = getKernels(params)
+    # we run SVD
+    W, U, mu = mexSVDsmall2(Params, dWU, W, iC, iW, Ka, Kb)
+
+    # we re-compute similarity scores between templates
+    WtW, iList = getMeWtW(W.astype(cp.float32), U.astype(cp.float32), Nnearest)
+    # ir.iList = iList  # over-write the list of nearest templates
+
+    isplit = simScore == 1  # overwrite the similarity scores of clusters with same parent
+    simScore = WtW.max(axis=2)
+    simScore[isplit] = 1  # 1 means they come from the same parent
+
+    iNeigh = iList[:, :Nfilt]  # get the new neighbor templates
+    iNeighPC = iC[:, iW[:Nfilt]]  # get the new neighbor channels
+
+    # for Phy, we need to pad the spikes with zeros so the spikes are aligned to the center of
+    # the window
+    Wphy = cp.concatenate(
+        (cp.zeros((1 + nt0min, Nfilt, Nrank), order='F'), W), axis=0)
+
+    # ir.isplit = isplit  # keep track of origins for each cluster
+
+    return Bunch(
+        st3_s=st3,
+
+        W_s=W,
+        U_s=U,
+        mu_s=mu,
+        simScore_s=simScore,
+        iNeigh_s=iNeigh,
+        iNeighPC_s=iNeighPC,
+
+        Wphy=Wphy,
+        iList=iList,
+        isplit=isplit,
+    )
+
+
+def set_cutoff(ctx):
+    # after everything else is done, this function takes spike trains and cuts off
+    # any noise they might have picked up at low amplitude values
+    # We look for bimodality in the amplitude plot, thus setting an individual threshold
+    # for each neuron.
+    # Also, this function calls "good" and "bad" clusters based on the auto-correlogram
+
+    ir = ctx.intermediate
+    params = ctx.params
+
+    st3 = cp.asarray(ir.st3_s0)  # st3_s0 is saved by the second splitting step
+    # cProj = ir.cProj
+    # cProjPC = ir.cProjPC
+
+    dt = 1. / 1000  # step size for CCG binning
+
+    Nk = int(st3[:, 1].max()) + 1  # number of templates
+
+    # sort by firing rate first
+    good = cp.zeros(Nk)
+    Ths = cp.zeros(Nk)
+    est_contam_rate = cp.zeros(Nk)
+
+    for j in tqdm(range(Nk), desc='Setting cutoff'):
+        ix = cp.where(st3[:, 1] == j)[0]  # find all spikes from this neuron
+        ss = st3[ix, 0] / params.fs  # convert to seconds
+        if ss.size == 0:
+            continue  # break if there are no spikes
+
+        vexp = st3[ix, 3]  # vexp is the relative residual variance of the spikes
+
+        Th = params.Th[0]  # start with a high threshold
+
+        fcontamination = 0.1  # acceptable contamination rate
+        est_contam_rate[j] = 1
+
+        while Th > params.Th[1]:
+            # continually lower the threshold, while the estimated unit contamination is low
+            st = ss[vexp > Th]  # take spikes above the current threshold
+            if len(st) == 0:
+                Th -= 0.5  # if there are no spikes, we need to keep lowering the threshold
+                continue
+
+            # compute the auto-correlogram with 500 bins at 1ms bins
+            K, Qi, Q00, Q01, rir = ccg(st, st, 500, dt)
+            # this is a measure of refractoriness
+            Q = (Qi / max(Q00, Q01)).min()
+            # this is a second measure of refractoriness (kicks in for very low firing rates)
+            R = rir.min()
+            # if the unit is already contaminated, we break, and use the next higher threshold
+            if (Q > fcontamination) or (R > 0.05):
+                break
+            else:
+                if (Th == params.Th[0]) and (Q < 0.05):
+                    # only on the first iteration, we consider if the unit starts well isolated
+                    # if it does, then we put much stricter criteria for isolation
+                    # to make sure we don't settle for a relatively high contamination unit
+                    fcontamination = min(0.05, max(0.01, Q * 2))
+
+                    # if the unit starts out contaminated, we will settle with the higher
+                    # contamination rate
+
+                # this unit is good, because we will stop lowering the threshold when it
+                # becomes bad
+                good[j] = 1
+                Th -= 0.5
+
+        # we exited the loop because the contamination was too high. We revert to the higher
+        # threshold
+        Th += 0.5
+        st = ss[vexp > Th]  # take spikes above the current threshold
+        # compute the auto-correlogram with 500 bins at 1ms bins
+        K, Qi, Q00, Q01, rir = ccg(st, st, 500, dt)
+        # this is a measure of refractoriness
+        Q = (Qi / max(Q00, Q01)).min()
+        est_contam_rate[j] = Q  # this score will be displayed in Phy
+
+        Ths[j] = Th  # store the threshold for potential debugging
+
+        # any spikes below the threshold get discarded into a 0-th cluster
+        st3[ix[vexp <= Th], 1] = -1
+
+    # we sometimes get NaNs, why? replace with full contamination
+    # (DEV_NOTES) this seems to occur when both Qi and max(Q00, Q01) are zero thus when dividing
+    # the two to get Q the result is a NaN
+
+    est_contam_rate[cp.isnan(est_contam_rate)] = 1
+
+    # remove spikes assigned to the -1 cluster
+    ix = st3[:, 1] == -1
+    st3 = st3[~ix, :]
+
+    # NOTE: to avoid loading everything into memory, we don't export cProj and cProjPC
+    # right now, we'll remove the spikes at the rezToPhy stage.
+
+    # if len(cProj) > 0:
+    #     ix = cp.asnumpy(ix)
+    #     if len(ix) > cProj.shape[0]:
+    #         ix = ix[:cProj.shape[0]]
+    #     else:
+    #         ix = np.pad(ix, (0, cProj.shape[0] - len(ix)), mode='constant')
+    #     assert ix.shape[0] == cProj.shape[0] == cProjPC.shape[0]
+    #     cProj = cProj[~ix, :]  # remove their template projections too
+    #     cProjPC = cProjPC[~ix, :, :]  # and their PC projections
+    #     assert st3.shape[0] == cProj.shape[0] == cProjPC.shape[0]
+
+    return Bunch(
+        st3_c=st3,  # the spikes assigned to -1 have been removed here
+        spikes_to_remove=cp.asnumpy(ix),
+        # cProj_c=cProj,
+        # cProjPC_c=cProjPC,
+
+        est_contam_rate=est_contam_rate,
+        Ths=Ths,
+        good=good,
+    )
+
+
+def checkClusters(ctx):
+    # Checks integrity of clusters. Removes clusters with 0 spikes.
+
+    # 1) List all cluster ids for spikes.
+    # 2) Find missing ids
+    # 3) Remove these indices from every variable that has n_clusters
+
+    ir = ctx.intermediate
+    max_id = int(np.max(ir.st3_c[:, 1])) + 1
+    ids = cp.asnumpy(np.unique(ir.st3_c[:, 1]).astype(np.int))
+    # Check if the max cluster id is equal to the number of cluster ids assigned to spikes.
+    if max_id != len(ids):  # see which cluster ids are missing
+        good_units_mask = np.isin(np.arange(max_id), ids)
+        # Remove clusters from fields in `ir` based on `good_units_mask`
+        # ir.dWU = ir.dWU[:, :, good_units_mask]
+        ir.iNeigh_s = ir.iNeigh_s[:, good_units_mask]
+        ir.iNeighPC_s = ir.iNeighPC_s[:, good_units_mask]
+        ir.mu_s = ir.mu_s[good_units_mask]
+        ir.simScore_s = ir.simScore_s[good_units_mask][:, good_units_mask]
+        ir.U_s = ir.U_s[:, good_units_mask, :]
+        # ir.UA = ir.UA[:, good_units_mask, :, :]
+        # ir.U_a = ir.U_a[:, :, good_units_mask]
+        # ir.U_b = ir.U_b[:, :, good_units_mask]
+        ir.W_s = ir.W_s[:, good_units_mask, :]
+        # ir.WA = ir.WA[:, good_units_mask, :, :]
+        # ir.W_a = ir.W_a[:, :, good_units_mask]
+        # ir.W_b = ir.W_b[:, :, good_units_mask]
+        ir.Wphy = ir.Wphy[:, good_units_mask, :]
+        ir.iList = ir.iList[:, good_units_mask]
+        ir.isplit = ir.isplit[good_units_mask][:, good_units_mask]
+        ir.est_contam_rate = ir.est_contam_rate[good_units_mask]
+        ir.Ths = ir.Ths[good_units_mask]
+        ir.good = ir.good[good_units_mask]
+
+        # Find empty cluster ids, and for spikes with cluster ids above those indices, subtract 1.
+        empty_cl = np.nonzero(~good_units_mask)[0]
+        for cl in empty_cl[::-1]:
+            logger.debug("Removing empty cluster %d.", cl)
+            mislabeled_cl = np.where(ir.st3_c[:, 1] > cl)[0]
+            ir.st3_c[mislabeled_cl, 1] -= 1
+
+    ctx.ir = ir
+    return ctx
+
+
+def rezToPhy(ctx, dat_path=None, output_dir=None):
+    # pull out results from kilosort's rez to either return to workspace or to
+    # save in the appropriate format for the phy GUI to run on. If you provide
+    # a savePath it should be a folder
+
+    savePath = output_dir
+    Path(savePath).mkdir(exist_ok=True, parents=True)
+
+    ctx = checkClusters(ctx)  # check clusters integrity
+
+    probe = ctx.probe
+    ir = ctx.intermediate
+    params = ctx.params
+    nt0 = params.nt0
+
+    # spikeTimes will be in samples, not seconds
+    W = cp.asarray(ir.Wphy).astype(np.float32)
+    Wrot = ir.Wrot
+    est_contam_rate = ir.est_contam_rate
+    good = ir.good
+    Ths = ir.Ths
+
+    st3 = cp.asarray(ir.st3_c)
+
+    U = cp.asarray(ir.U_s).astype(np.float32)
+    iNeigh = ir.iNeigh_s
+    iNeighPC = ir.iNeighPC_s
+    simScore = ir.simScore_s
+
+    if st3.shape[1] > 4:
+        st3 = st3[:, :4]
+
+    isort = cp.argsort(st3[:, 0])
+    st3 = st3[isort, :]
+    # cProj = ir.cProj_c[cp.asnumpy(isort), :]
+    # cProjPC = ir.cProjPC_c[cp.asnumpy(isort), :, :]
+
+    fs = os.listdir(savePath)
+    for file in fs:
+        if file.endswith('.npy'):
+            os.remove(join(savePath, file))
+    if os.path.isdir(join(savePath, '.phy')):
+        shutil.rmtree(join(savePath, '.phy'))
+
+    spikeTimes = st3[:, 0].astype(cp.uint64)
+    spikeTemplates = st3[:, 1].astype(cp.uint32)
+
+    # (DEV_NOTES) if statement below seems useless due to above if statement
+    if st3.shape[1] > 4:
+        spikeClusters = (1 + st3[:, 4]).astype(cp.uint32)
+
+    # templateFeatures = cProj
+    templateFeatureInds = iNeigh.astype(cp.uint32)
+    # pcFeatures = cProjPC
+    pcFeatureInds = iNeighPC.astype(cp.uint32)
+
+    whiteningMatrix = cp.asarray(Wrot) / params.scaleproc
+    whiteningMatrixInv = cp.linalg.pinv(whiteningMatrix)
+
+    amplitudes = st3[:, 2]
+
+    Nchan = probe.Nchan
+
+    xcoords = probe.xc
+    ycoords = probe.yc
+    chanMap = probe.chanMap
+    chanMap0ind = chanMap  # - 1
+
+    nt0, Nfilt = W.shape[:2]
+
+    # (DEV_NOTES) 2 lines below can be combined
+    # templates = cp.einsum('ikl,jkl->ijk', U, W).astype(cp.float32)
+    # templates = cp.zeros((Nchan, nt0, Nfilt), dtype=np.float32, order='F')
+    tempAmpsUnscaled = cp.zeros(Nfilt, dtype=np.float32)
+    templates_writer = NpyWriter(join(savePath, 'templates.npy'), (Nfilt, nt0, Nchan), np.float32)
+    for iNN in tqdm(range(Nfilt), desc="Computing templates"):
+        t = cp.dot(U[:, iNN, :], W[:, iNN, :].T).T
+        templates_writer.append(t)
+        t_unw = cp.dot(t, whiteningMatrixInv)
+        assert t_unw.ndim == 2
+        tempChanAmps = t_unw.max(axis=0) - t_unw.min(axis=0)
+        tempAmpsUnscaled[iNN] = tempChanAmps.max()
+
+    templates_writer.close()
+    # templates = cp.transpose(templates, (2, 1, 0))  # now it's nTemplates x nSamples x nChannels
+    # we include all channels so this is trivial
+    templatesInds = cp.tile(np.arange(Nfilt), (Nchan, 1))
+
+    # here we compute the amplitude of every template...
+
+    # unwhiten all the templates
+    # tempsUnW = cp.einsum('ijk,kl->ijl', templates, whiteningMatrixinv)
+    # tempsUnW = cp.zeros(templates.shape, dtype=np.float32, order='F')
+    # for t in tqdm(range(templates.shape[0]), desc="Unwhitening the templates"):
+    #     tempsUnW[t, :, :] = cp.dot(templates[t, :, :], whiteningMatrixInv)
+
+    # The amplitude on each channel is the positive peak minus the negative
+    # tempChanAmps = tempsUnW.max(axis=1) - tempsUnW.min(axis=1)
+
+    # The template amplitude is the amplitude of its largest channel
+    # tempAmpsUnscaled = tempChanAmps.max(axis=1)
+
+    # assign all spikes the amplitude of their template multiplied by their
+    # scaling amplitudes
+    # tempAmpsUnscaled = cp.(tempAmpsUnscaled, axis=0).astype(np.float32)
+    spikeAmps = tempAmpsUnscaled[spikeTemplates] * amplitudes
+
+    # take the average of all spike amps to get actual template amps (since
+    # tempScalingAmps are equal mean for all templates)
+    ta = clusterAverage(spikeTemplates, spikeAmps)
+    tids = cp.unique(spikeTemplates).astype(np.int64)
+    tempAmps = cp.zeros_like(tempAmpsUnscaled, order='F')
+    tempAmps[tids] = ta  # because ta only has entries for templates that had at least one spike
+    tempAmps = params.gain * tempAmps  # for consistency, make first dimension template number
+
+    # PCs
+    ix = ir.spikes_to_remove  # length: number of spikes BEFORE -1 cluster removed
+
+    cProj_shape = ir.cProj.shape
+    cProj_shape = (st3.shape[0],) + cProj_shape[1:]
+
+    cProjPC_shape = ir.cProjPC.shape
+    cProjPC_shape = (st3.shape[0],) + cProjPC_shape[1:]
+
+    tfw = NpyWriter(join(savePath, 'template_features.npy'), cProj_shape, np.float32)
+    pcw = NpyWriter(join(savePath, 'pc_features.npy'), cProjPC_shape, np.float32)
+
+    isort = cp.asnumpy(isort)
+    N = len(ix)  # number of spikes including those assigned to -1
+    assert ir.cProj.shape[0] == N
+    assert ir.cProjPC.shape[0] == N
+
+    spikes_to_keep = np.nonzero(~ix)[0]  # indices of the spikes to keep in the cProj index space
+
+    # if len(ix) > ir.cProj.shape[0]:
+    #     ix = ix[:cProj.shape[0]]
+    # else:
+    #     ix = np.pad(ix, (0, ir.cProj.shape[0] - len(ix)), mode='constant')
+    # assert ix.shape[0] == ir.cProj.shape[0] == ir.cProjPC.shape[0]
+
+    k = int(ceil(float(N) / 100))  # 100 chunks
+    assert k >= 1
+    for i in tqdm(range(0, N, k), desc="Saving template and PC features"):
+        # NOTE: cProj and cProjPC still have the spikes assigned to -1 that have yet to be removed
+
+        # spike indices in cProj that need to be kept in this chunk
+        ind = spikes_to_keep[isort[i:i + k]]
+
+        cProj = ir.cProj[ind]
+        cProjPC = ir.cProjPC[ind]
+
+        tfw.append(cProj)
+        pcw.append(cProjPC)
+    tfw.close()
+    pcw.close()
+    # with open(, 'wb') as fp:
+    #     save_large_array(fp, templateFeatures)
+    # cProj = ir.cProj_c[cp.asnumpy(isort), :]
+    # cProjPC = ir.cProjPC_c[cp.asnumpy(isort), :, :]
+
+    def _save(name, arr, dtype=None):
+        cp.save(join(savePath, name + '.npy'), arr.astype(dtype or arr.dtype))
+
+    if savePath is not None:
+        _save('spike_times', spikeTimes)
+        _save('spike_templates', spikeTemplates, cp.uint32)
+        if st3.shape[1] > 4:
+            _save('spike_clusters', spikeClusters, cp.uint32)
+        else:
+            _save('spike_clusters', spikeTemplates, cp.uint32)
+        _save('amplitudes', amplitudes)
+        # _save('templates', templates)
+        _save('templates_ind', templatesInds)
+
+        chanMap0ind = chanMap0ind.astype(cp.int32)
+
+        _save('channel_map', chanMap0ind)
+        _save('channel_positions', np.c_[xcoords, ycoords])
+
+        # _save('template_features', templateFeatures)
+        # with open(join(savePath, 'template_features.npy'), 'wb') as fp:
+        #     save_large_array(fp, templateFeatures)
+        _save('template_feature_ind', templateFeatureInds.T)
+
+        # _save('pc_features', pcFeatures)
+        # with open(join(savePath, 'pc_features.npy'), 'wb') as fp:
+        #     save_large_array(fp, pcFeatures)
+        _save('pc_feature_ind', pcFeatureInds.T)
+
+        _save('whitening_mat', whiteningMatrix)
+        _save('whitening_mat_inv', whiteningMatrixInv)
+
+        _save('thresholds', Ths)
+
+        if 'simScore' in ir:
+            similarTemplates = simScore
+            _save('similar_templates', similarTemplates)
+
+        est_contam_rate[np.isnan(est_contam_rate)] = 1
+        with open(join(savePath, 'cluster_group.tsv'), 'w') as f:
+            f.write('cluster_id\tgroup\n')
+            for j in range(len(good)):
+                if good[j]:
+                    f.write('%d\tgood\n' % j)
+                # else:
+                #     f.write('%d\tmua\n' % j)
+
+        with open(join(savePath, 'cluster_ContamPct.tsv'), 'w') as f:
+            f.write('cluster_id\tContamPct\n')
+            for j in range(len(good)):
+                f.write('%d\t%.1f\n' % (j, 100 * est_contam_rate[j]))
+
+        with open(join(savePath, 'cluster_Amplitude.tsv'), 'w') as f:
+            f.write('cluster_id\tAmplitude\n')
+            for j in range(len(good)):
+                f.write('%d\t%.1f\n' % (j, tempAmps[j]))
+
+        # make params file
+        if not os.path.exists(join(savePath, 'params.py')):
+            with open(join(savePath, 'params.py'), 'w') as f:
+                f.write('dat_path = "../%s"\n' % dat_path)
+                f.write('n_channels_dat = %d\n' % probe.NchanTOT)
+                f.write('dtype = "int16"\n')
+                f.write('offset = 0\n')
+                f.write('hp_filtered = False\n')
+                f.write('sample_rate = %i\n' % params.fs)
+                f.write('template_scaling = %.1f\n' % params.get('templateScaling', 1.0))

--- a/pykilosort/preprocess.py
+++ b/pykilosort/preprocess.py
@@ -1,0 +1,420 @@
+import logging
+from math import ceil
+from functools import lru_cache
+
+import numpy as np
+from scipy.signal import butter
+import cupy as cp
+from tqdm import tqdm
+
+from .cptools import lfilter, _get_lfilter_fun, median, convolve_gpu
+from .utils import _make_fortran
+
+logger = logging.getLogger(__name__)
+
+
+def get_filter_params(fs, fshigh=None, fslow=None):
+    if fslow and fslow < fs / 2:
+        # butterworth filter with only 3 nodes (otherwise it's unstable for float32)
+        return butter(3, (2 * fshigh / fs, 2 * fslow / fs), 'bandpass')
+    else:
+        # butterworth filter with only 3 nodes (otherwise it's unstable for float32)
+        return butter(3, fshigh / fs * 2, 'high')
+
+
+def gpufilter(buff, chanMap=None, fs=None, fslow=None, fshigh=None, car=True):
+    # filter this batch of data after common average referencing with the
+    # median
+    # buff is timepoints by channels
+    # chanMap are indices of the channels to be kep
+    # params.fs and params.fshigh are sampling and high-pass frequencies respectively
+    # if params.fslow is present, it is used as low-pass frequency (discouraged)
+
+    # set up the parameters of the filter
+    b1, a1 = get_filter_params(fs, fshigh=fshigh, fslow=fslow)
+
+    dataRAW = buff  # .T  # NOTE: we no longer use Fortran order upstream
+    assert dataRAW.flags.c_contiguous
+    assert dataRAW.ndim == 2
+    assert dataRAW.shape[0] > dataRAW.shape[1]
+    if chanMap is not None and len(chanMap):
+        dataRAW = dataRAW[:, chanMap]  # subsample only good channels
+    assert dataRAW.ndim == 2
+
+    # subtract the mean from each channel
+    dataRAW = dataRAW - cp.mean(dataRAW, axis=0)  # subtract mean of each channel
+    assert dataRAW.ndim == 2
+
+    # CAR, common average referencing by median
+    if car:
+        # subtract median across channels
+        dataRAW = dataRAW - median(dataRAW, axis=1)[:, np.newaxis]
+
+    # next four lines should be equivalent to filtfilt (which cannot be
+    # used because it requires float64)
+    datr = lfilter(b1, a1, dataRAW, axis=0)  # causal forward filter
+    datr = lfilter(b1, a1, datr, axis=0, reverse=True)  # backward
+    return datr
+
+
+def _is_vect(x):
+    return hasattr(x, '__len__') and len(x) > 1
+
+
+def _make_vect(x):
+    if not hasattr(x, '__len__'):
+        x = np.array([x])
+    return x
+
+
+def my_min(S1, sig, varargin=None):
+    # returns a running minimum applied sequentially across a choice of dimensions and bin sizes
+    # S1 is the matrix to be filtered
+    # sig is either a scalar or a sequence of scalars, one for each axis to be filtered.
+    #  it's the plus/minus bin length for the minimum filter
+    # varargin can be the dimensions to do filtering, if len(sig) != x.shape
+    # if sig is scalar and no axes are provided, the default axis is 2
+    idims = 1
+    if varargin is not None:
+        idims = varargin
+    idims = _make_vect(idims)
+    if _is_vect(idims) and _is_vect(sig):
+        sigall = sig
+    else:
+        sigall = np.tile(sig, len(idims))
+
+    for sig, idim in zip(sigall, idims):
+        Nd = S1.ndim
+        S1 = cp.transpose(S1, [idim] + list(range(0, idim)) + list(range(idim + 1, Nd)))
+        dsnew = S1.shape
+        S1 = cp.reshape(S1, (S1.shape[0], -1), order='F' if S1.flags.f_contiguous else 'C')
+        dsnew2 = S1.shape
+        S1 = cp.concatenate(
+            (cp.full((sig, dsnew2[1]), np.inf), S1, cp.full((sig, dsnew2[1]), np.inf)), axis=0)
+        Smax = S1[:dsnew2[0], :]
+        for j in range(1, 2 * sig + 1):
+            Smax = cp.minimum(Smax, S1[j:j + dsnew2[0], :])
+        S1 = cp.reshape(Smax, dsnew, order='F' if S1.flags.f_contiguous else 'C')
+        S1 = cp.transpose(S1, list(range(1, idim + 1)) + [0] + list(range(idim + 1, Nd)))
+    return S1
+
+
+def my_sum(S1, sig, varargin=None):
+    # returns a running sum applied sequentially across a choice of dimensions and bin sizes
+    # S1 is the matrix to be filtered
+    # sig is either a scalar or a sequence of scalars, one for each axis to be filtered.
+    #  it's the plus/minus bin length for the summing filter
+    # varargin can be the dimensions to do filtering, if len(sig) != x.shape
+    # if sig is scalar and no axes are provided, the default axis is 2
+    idims = 1
+    if varargin is not None:
+        idims = varargin
+    idims = _make_vect(idims)
+    if _is_vect(idims) and _is_vect(sig):
+        sigall = sig
+    else:
+        sigall = np.tile(sig, len(idims))
+
+    for sig, idim in zip(sigall, idims):
+        Nd = S1.ndim
+        S1 = cp.transpose(S1, [idim] + list(range(0, idim)) + list(range(idim + 1, Nd)))
+        dsnew = S1.shape
+        S1 = cp.reshape(S1, (S1.shape[0], -1), order='F')
+        dsnew2 = S1.shape
+        S1 = cp.concatenate(
+            (cp.full((sig, dsnew2[1]), 0), S1, cp.full((sig, dsnew2[1]), 0)), axis=0)
+        Smax = S1[:dsnew2[0], :]
+        for j in range(1, 2 * sig + 1):
+            Smax = Smax + S1[j:j + dsnew2[0], :]
+        S1 = cp.reshape(Smax, dsnew, order='F')
+        S1 = cp.transpose(S1, list(range(1, idim + 1)) + [0] + list(range(idim + 1, Nd)))
+    return S1
+
+
+def my_conv2(x, sig, varargin=None, **kwargs):
+    # x is the matrix to be filtered along a choice of axes
+    # sig is either a scalar or a sequence of scalars, one for each axis to be filtered
+    # varargin can be the dimensions to do filtering, if len(sig) != x.shape
+    # if sig is scalar and no axes are provided, the default axis is 2
+    if sig <= .25:
+        return x
+    idims = 1
+    if varargin is not None:
+        idims = varargin
+    idims = _make_vect(idims)
+    if _is_vect(idims) and _is_vect(sig):
+        sigall = sig
+    else:
+        sigall = np.tile(sig, len(idims))
+
+    for sig, idim in zip(sigall, idims):
+        Nd = x.ndim
+        x = cp.transpose(x, [idim] + list(range(0, idim)) + list(range(idim + 1, Nd)))
+        dsnew = x.shape
+        x = cp.reshape(x, (x.shape[0], -1), order='F')
+
+        tmax = ceil(4 * sig)
+        dt = cp.arange(-tmax, tmax + 1)
+        gaus = cp.exp(-dt ** 2 / (2 * sig ** 2))
+        gaus = gaus / cp.sum(gaus)
+
+        y = convolve_gpu(x, gaus, **kwargs)
+        y = y.reshape(dsnew, order='F')
+        y = cp.transpose(y, list(range(1, idim + 1)) + [0] + list(range(idim + 1, Nd)))
+    return y
+
+
+def whiteningFromCovariance(CC):
+    # function Wrot = whiteningFromCovariance(CC)
+    # takes as input the matrix CC of channel pairwise correlations
+    # outputs a symmetric rotation matrix (also Nchan by Nchan) that rotates
+    # the data onto uncorrelated, unit-norm axes
+
+    # covariance eigendecomposition (same as svd for positive-definite matrix)
+    E, D, _ = cp.linalg.svd(CC)
+    eps = 1e-6
+    Di = cp.diag(1. / (D + eps) ** .5)
+    Wrot = cp.dot(cp.dot(E, Di), E.T)  # this is the symmetric whitening matrix (ZCA transform)
+    return Wrot
+
+
+def whiteningLocal(CC, yc, xc, nRange):
+    # function to perform local whitening of channels
+    # CC is a matrix of Nchan by Nchan correlations
+    # yc and xc are vector of Y and X positions of each channel
+    # nRange is the number of nearest channels to consider
+    Wrot = cp.zeros((CC.shape[0], CC.shape[0]))
+
+    for j in range(CC.shape[0]):
+        ds = (xc - xc[j]) ** 2 + (yc - yc[j]) ** 2
+        ilocal = np.argsort(ds)
+        # take the closest channels to the primary channel.
+        # First channel in this list will always be the primary channel.
+        ilocal = ilocal[:nRange]
+
+        wrot0 = cp.asnumpy(whiteningFromCovariance(CC[np.ix_(ilocal, ilocal)]))
+        # the first column of wrot0 is the whitening filter for the primary channel
+        Wrot[ilocal, j] = wrot0[:, 0]
+
+    return Wrot
+
+
+def get_whitening_matrix(raw_data=None, probe=None, params=None):
+    """
+    based on a subset of the data, compute a channel whitening matrix
+    this requires temporal filtering first (gpufilter)
+    """
+    Nbatch = get_Nbatch(raw_data, params)
+    ntbuff = params.ntbuff
+    NTbuff = params.NTbuff
+    whiteningRange = params.whiteningRange
+    scaleproc = params.scaleproc
+    NT = params.NT
+    fs = params.fs
+    fshigh = params.fshigh
+    nSkipCov = params.nSkipCov
+
+    xc = probe.xc
+    yc = probe.yc
+    chanMap = probe.chanMap
+    Nchan = probe.Nchan
+    chanMap = probe.chanMap
+
+    # Nchan is obtained after the bad channels have been removed
+    CC = cp.zeros((Nchan, Nchan))
+
+    for ibatch in tqdm(range(0, Nbatch, nSkipCov), desc="Computing the whitening matrix"):
+        i = max(0, (NT - ntbuff) * ibatch - 2 * ntbuff)
+        # WARNING: we no longer use Fortran order, so raw_data is nsamples x NchanTOT
+        buff = raw_data[i:i + NT - ntbuff]
+        assert buff.shape[0] > buff.shape[1]
+        assert buff.flags.c_contiguous
+
+        nsampcurr = buff.shape[0]
+        if nsampcurr < NTbuff:
+            buff = np.concatenate(
+                (buff, np.tile(buff[nsampcurr - 1], (NTbuff, 1))), axis=0)
+
+        buff_g = cp.asarray(buff, dtype=np.float32)
+
+        # apply filters and median subtraction
+        datr = gpufilter(buff_g, fs=fs, fshigh=fshigh, chanMap=chanMap)
+        assert datr.flags.c_contiguous
+
+        CC = CC + cp.dot(datr.T, datr) / NT  # sample covariance
+
+    CC = CC / ceil((Nbatch - 1) / nSkipCov)
+
+    if whiteningRange < np.inf:
+        #  if there are too many channels, a finite whiteningRange is more robust to noise
+        # in the estimation of the covariance
+        whiteningRange = min(whiteningRange, Nchan)
+        # this function performs the same matrix inversions as below, just on subsets of
+        # channels around each channel
+        Wrot = whiteningLocal(CC, yc, xc, whiteningRange)
+    else:
+        Wrot = whiteningFromCovariance(CC)
+
+    Wrot = Wrot * scaleproc
+
+    logger.info("Computed the whitening matrix.")
+
+    return Wrot
+
+
+def get_good_channels(raw_data=None, probe=None, params=None):
+    """
+    of the channels indicated by the user as good (chanMap)
+    further subset those that have a mean firing rate above a certain value
+    (default is ops.minfr_goodchannels = 0.1Hz)
+    needs the same filtering parameters in ops as usual
+    also needs to know where to start processing batches (twind)
+    and how many channels there are in total (NchanTOT)
+    """
+    fs = params.fs
+    fshigh = params.fshigh
+    fslow = params.fslow
+    Nbatch = get_Nbatch(raw_data, params)
+    NT = params.NT
+    spkTh = params.spkTh
+    nt0 = params.nt0
+    minfr_goodchannels = params.minfr_goodchannels
+
+    chanMap = probe.chanMap
+    # Nchan = probe.Nchan
+    NchanTOT = len(chanMap)
+
+    ich = []
+    k = 0
+    ttime = 0
+
+    # skip every 100 batches
+    for ibatch in tqdm(range(0, Nbatch, int(ceil(Nbatch / 100))), desc="Finding good channels"):
+        i = NT * ibatch
+        buff = raw_data[i:i + NT]
+        # buff = _make_fortran(buff)
+        # NOTE: using C order now
+        assert buff.shape[0] > buff.shape[1]
+        assert buff.flags.c_contiguous
+        if buff.size == 0:
+            break
+
+        # Put on GPU.
+        buff = cp.asarray(buff, dtype=np.float32)
+        assert buff.flags.c_contiguous
+        datr = gpufilter(buff, chanMap=chanMap, fs=fs, fshigh=fshigh, fslow=fslow)
+        assert datr.shape[0] > datr.shape[1]
+
+        # very basic threshold crossings calculation
+        s = cp.std(datr, axis=0)
+        datr = datr / s  # standardize each channel ( but don't whiten)
+        mdat = my_min(datr, 30, 0)  # get local minima as min value in +/- 30-sample range
+
+        # take local minima that cross the negative threshold
+        xi, xj = cp.nonzero((datr < mdat + 1e-3) & (datr < spkTh))
+
+        # filtering may create transients at beginning or end. Remove those.
+        xj = xj[(xi >= nt0) & (xi <= NT - nt0)]
+
+        # collect the channel identities for the detected spikes
+        ich.append(xj)
+        k += xj.size
+
+        # keep track of total time where we took spikes from
+        ttime += datr.shape[0] / fs
+
+    ich = cp.concatenate(ich)
+
+    # count how many spikes each channel got
+    nc, _ = cp.histogram(ich, cp.arange(NchanTOT + 1))
+
+    # divide by total time to get firing rate
+    nc = nc / ttime
+
+    # keep only those channels above the preset mean firing rate
+    igood = cp.asnumpy(nc >= minfr_goodchannels)
+
+    if len(igood) == 0:
+        raise RuntimeError("No good channels found! Verify your raw data and parameters.")
+
+    logger.info('Found %d threshold crossings in %2.2f seconds of data.' % (k, ttime))
+    logger.info('Found %d/%d bad channels.' % (np.sum(~igood), len(igood)))
+
+    return igood
+
+
+def get_Nbatch(raw_data, params):
+    n_samples = max(raw_data.shape)
+    # we assume raw_data as been already virtually split with the requested trange
+    return ceil(n_samples / (params.NT - params.ntbuff))  # number of data batches
+
+
+def preprocess(ctx):
+    # function rez = preprocessDataSub(ops)
+    # this function takes an ops struct, which contains all the Kilosort2 settings and file paths
+    # and creates a new binary file of preprocessed data, logging new variables into rez.
+    # The following steps are applied:
+    # 1) conversion to float32
+    # 2) common median subtraction
+    # 3) bandpass filtering
+    # 4) channel whitening
+    # 5) scaling to int16 values
+
+    params = ctx.params
+    probe = ctx.probe
+    raw_data = ctx.raw_data
+    ir = ctx.intermediate
+
+    fs = params.fs
+    fshigh = params.fshigh
+    fslow = params.fslow
+    Nbatch = ir.Nbatch
+    NT = params.NT
+    NTbuff = params.NTbuff
+
+    Wrot = cp.asarray(ir.Wrot)
+
+    logger.info("Loading raw data and applying filters.")
+
+    with open(ir.proc_path, 'wb') as fw:  # open for writing processed data
+        for ibatch in tqdm(range(Nbatch), desc="Preprocessing"):
+            # we'll create a binary file of batches of NT samples, which overlap consecutively
+            # on params.ntbuff samples
+            # in addition to that, we'll read another params.ntbuff samples from before and after,
+            # to have as buffers for filtering
+
+            # number of samples to start reading at.
+            i = max(0, (NT - params.ntbuff) * ibatch - 2 * params.ntbuff)
+            if ibatch == 0:
+                # The very first batch has no pre-buffer, and has to be treated separately
+                ioffset = 0
+            else:
+                ioffset = params.ntbuff
+
+            buff = raw_data[i:i + NTbuff]
+            if buff.size == 0:
+                logger.error("Loaded buffer has an empty size!")
+                break  # this shouldn't really happen, unless we counted data batches wrong
+
+            nsampcurr = buff.shape[0]  # how many time samples the current batch has
+            if nsampcurr < NTbuff:
+                buff = np.concatenate(
+                    (buff, np.tile(buff[nsampcurr - 1], (NTbuff, 1))), axis=0)
+
+            # apply filters and median subtraction
+            buff = cp.asarray(buff, dtype=np.float32)
+
+            datr = gpufilter(buff, chanMap=probe.chanMap, fs=fs, fshigh=fshigh, fslow=fslow)
+            assert datr.flags.c_contiguous
+
+            datr = datr[ioffset:ioffset + NT, :]  # remove timepoints used as buffers
+            datr = cp.dot(datr, Wrot)  # whiten the data and scale by 200 for int16 range
+            assert datr.flags.c_contiguous
+
+            # convert to int16, and gather on the CPU side
+            # WARNING: transpose because "tofile" always writes in C order, whereas we want
+            # to write in F order.
+            datcpu = cp.asnumpy(datr.T.astype(np.int16))
+
+            # write this batch to binary file
+            datcpu.tofile(fw)

--- a/pykilosort/tests/conftest.py
+++ b/pykilosort/tests/conftest.py
@@ -1,0 +1,88 @@
+from math import ceil
+from pathlib import Path
+from pytest import fixture
+
+import numpy as np
+
+from ..utils import Bunch, read_data
+from .. import add_default_handler
+
+
+add_default_handler(level='DEBUG')
+
+
+@fixture
+def data_path():
+    path = (Path(__file__).parent / '../../data/').resolve()
+    assert path.exists()
+    return path
+
+
+@fixture
+def dat_path(data_path):
+    return data_path / 'imec_385_100s.bin'
+
+
+@fixture
+def raw_data(dat_path):
+    # WARNING: Fortran order
+    return read_data(dat_path, shape=(385, -1), dtype=np.int16)
+
+
+@fixture
+def params():
+
+    np.random.seed(0)
+
+    params = Bunch()
+
+    params.fs = 30000.
+    params.fshigh = 150.
+    params.fslow = None
+    params.ntbuff = 64
+    params.NT = 65600
+    params.NTbuff = params.NT + 4 * params.ntbuff  # we need buffers on both sides for filtering
+    params.nSkipCov = 25
+    params.whiteningRange = 32
+    params.scaleproc = 200
+    params.spkTh = -6
+    params.nt0 = 61
+    params.minfr_goodchannels = .1
+    params.nfilt_factor = 4
+    params.nt0 = 61
+    params.nt0min = ceil(20 * params.nt0 / 61)
+
+    return params
+
+
+@fixture
+def probe(data_path):
+    probe = Bunch()
+    probe.NchanTOT = 385
+    # WARNING: indexing mismatch with MATLAB hence the -1
+    probe.chanMap = np.load(data_path / 'chanMap.npy').squeeze().astype(np.int64) - 1
+    probe.xc = np.load(data_path / 'xc.npy').squeeze()
+    probe.yc = np.load(data_path / 'yc.npy').squeeze()
+    probe.kcoords = np.load(data_path / 'kcoords.npy').squeeze()
+    return probe
+
+
+@fixture
+def probe_good(data_path, probe):
+    igood = np.load(data_path / 'igood.npy').squeeze()
+    probe.Nchan = np.sum(igood)
+    probe.chanMap = probe.chanMap[igood]
+    probe.xc = probe.xc[igood]
+    probe.yc = probe.yc[igood]
+    probe.kcoords = probe.kcoords[igood]
+    return probe
+
+
+@fixture(params=[np.float64, np.float32])
+def dtype(request):
+    return np.dtype(request.param)
+
+
+@fixture(params=[0, 1])
+def axis(request):
+    return request.param

--- a/pykilosort/tests/test_cptools.py
+++ b/pykilosort/tests/test_cptools.py
@@ -1,0 +1,109 @@
+import numpy as np
+from numpy.testing import assert_allclose as ac
+from scipy.signal import lfilter as lfilter_cpu
+import cupy as cp
+
+from pytest import fixture
+
+from ..cptools import (
+    median, lfilter, svdecon, svdecon_cpu, free_gpu_memory,
+    convolve_cpu, convolve_gpu, convolve_gpu_direct, convolve_gpu_chunked)
+
+
+def test_median_1(dtype, axis):
+    arr = cp.random.rand(2000, 1000).astype(dtype)
+    m1 = cp.asnumpy(median(arr, axis=axis))
+    m2 = np.median(cp.asnumpy(arr), axis=axis)
+    assert np.allclose(m1, m2)
+
+
+def test_lfilter_1():
+    tmax = 1000
+    dt = np.arange(-tmax, tmax + 1)
+    gaus = np.exp(-dt ** 2 / (2 * 250 ** 2))
+    b = gaus / np.sum(gaus)
+
+    a = 1.
+
+    n = 2000
+    arr = np.r_[np.ones(n), np.zeros(n)]
+
+    fil_gpu = cp.asnumpy(lfilter(b, a, cp.asarray(arr), axis=0)).ravel()
+    fil_cpu = lfilter_cpu(b, a, arr, axis=0)
+
+    assert np.allclose(fil_cpu, fil_gpu, atol=1e-6)
+
+
+def test_lfilter_2():
+    b = (0.96907117, -2.90721352, 2.90721352, -0.96907117)
+    a = (1., -2.93717073, 2.87629972, -0.93909894)
+    arr = np.random.rand(1000, 100).astype(np.float32)
+
+    fil_gpu = cp.asnumpy(lfilter(b, a, cp.asarray(arr), axis=0))
+    fil_cpu = lfilter_cpu(b, a, arr, axis=0)
+
+    assert np.allclose(fil_cpu, fil_gpu, atol=.2)
+
+
+def test_svdecon_1():
+    X = cp.random.rand(10, 10)
+
+    U, S, V = svdecon(X)
+    Un, Sn, Vn = svdecon_cpu(X)
+
+    assert np.allclose(S, Sn)
+
+
+@fixture(params=(100, 2_000, 10_000, 50_000, 250_000))
+def arr(request):
+    return np.random.randn(int(request.param), 100)
+
+
+@fixture
+def gaus():
+    dt = np.arange(-1000, 1000 + 1)
+    gaus = np.exp(-dt ** 2 / (2 * 250 ** 2))
+    return gaus / np.sum(gaus)
+
+
+@fixture(params=(None, 'zeros', 'flip', 'constant'))
+def pad(request):
+    return request.param
+
+
+@fixture
+def nwin():
+    return 2500
+
+
+def test_convolve(arr, gaus, pad, nwin):
+    free_gpu_memory()
+    npad = gaus.shape[0] // 2
+
+    # Upload the arrays to the GPU.
+    arr_gpu = cp.asarray(arr)
+    gaus_gpu = cp.asarray(gaus)
+
+    # Compute the convolution on the CPU.
+    conv_cpu = convolve_cpu(arr, gaus)
+
+    def check(y):
+        ac(cp.asnumpy(y)[npad:-npad, :], conv_cpu[npad:-npad, :], atol=1e-3)
+
+    # Check the GPU direct version with the CPU version.
+    check(convolve_gpu_direct(arr_gpu, gaus_gpu, pad=pad))
+
+    if arr.shape[0] > nwin:
+        # Check the GPU chunked version with the CPU version.
+        y = convolve_gpu_chunked(arr_gpu, gaus_gpu, pad=pad, nwin=nwin)
+        check(y)
+
+        # DEBUG
+        # import matplotlib.pyplot as plt
+        # plt.plot(cp.asnumpy(conv_cpu[npad:-npad, 0]))
+        # plt.plot(cp.asnumpy(y[npad:-npad, 0]))
+        # plt.show()
+
+    if pad is None:
+        # This function should automatically route to the correct GPU implementation.
+        check(convolve_gpu(arr_gpu, gaus_gpu))

--- a/pykilosort/tests/test_event.py
+++ b/pykilosort/tests/test_event.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+"""Test event system."""
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+from pytest import raises
+
+from ..event import EventEmitter
+
+
+#------------------------------------------------------------------------------
+# Test event system
+#------------------------------------------------------------------------------
+
+def test_event_system():
+    ev = EventEmitter()
+
+    _list = []
+
+    with raises(ValueError):
+        ev.connect(lambda x: x)
+
+    @ev.connect
+    def on_my_event(sender, arg, kwarg=None):
+        _list.append((arg, kwarg))
+
+    ev.emit('my_event', ev, 'a')
+    assert _list == [('a', None)]
+
+    ev.emit('my_event', ev, 'b', 'c')
+    assert _list == [('a', None), ('b', 'c')]
+
+    ev.unconnect(on_my_event)
+
+    ev.emit('my_event', ev, 'b', 'c')
+    assert _list == [('a', None), ('b', 'c')]
+
+
+def test_event_silent():
+    ev = EventEmitter()
+
+    _list = []
+
+    @ev.connect()
+    def on_test(sender, x):
+        _list.append(x)
+
+    ev.emit('test', ev, 1)
+    assert _list == [1]
+
+    with ev.silent():
+        ev.emit('test', ev, 1)
+    assert _list == [1]
+
+    ev.set_silent(True)
+
+
+def test_event_single():
+    ev = EventEmitter()
+
+    l = []
+
+    @ev.connect(event='test')
+    def on_test_bou(sender):
+        l.append(0)
+
+    @ev.connect  # noqa
+    def on_test(sender):
+        l.append(1)
+
+    ev.emit('test', ev)
+    assert l == [0, 1]
+
+    ev.emit('test', ev, single=True)
+    assert l == [0, 1, 0]

--- a/pykilosort/tests/test_preprocess.py
+++ b/pykilosort/tests/test_preprocess.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import numpy as np
+from scipy.signal import lfilter as lfilter_cpu
+import cupy as cp
+
+from ..preprocess import my_conv2
+
+sig = 250
+tmax = 1000
+
+test_path = Path(__file__).parent
+
+
+def test_convolve_real_data():
+
+    file_s1 = test_path.joinpath('my_conv2_input.npy')
+    file_expected = test_path.joinpath('my_conv2_output.npy')
+    if not file_s1.exists() or not file_expected.exists():
+        return
+    s1 = np.load(file_s1)
+    s1_expected = np.load(file_expected)
+
+    def plot(out):
+        import matplotlib.pyplot as plt
+        plt.plot(cp.asnumpy(out))
+        plt.plot(s1_expected)
+
+    def diff(out):
+        return np.max(np.abs(cp.asnumpy(out[1000:-1000, :1]) - s1_expected[1000:-1000, :1]))
+
+    x = cp.asarray(s1)
+    assert diff(my_conv2(x, 250, 0, nwin=0, pad=None)) < 1e-6
+    assert diff(my_conv2(x, 250, 0, nwin=0, pad='zeros')) < 1e-6
+    assert diff(my_conv2(x, 250, 0, nwin=0, pad='constant')) < 1e-6
+
+    assert diff(my_conv2(x, 250, 0, nwin=10000, pad=None)) < 1e-3
+    assert diff(my_conv2(x, 250, 0, nwin=10000, pad='zeros')) < 1e-3
+    assert diff(my_conv2(x, 250, 0, nwin=10000, pad='constant')) < 1e-3
+
+    assert diff(my_conv2(x, 250, 0, nwin=0, pad='flip')) < 1e-6
+    assert diff(my_conv2(x, 250, 0, nwin=10000, pad='flip')) < 1e-3
+
+
+def create_test_dataset():
+    cp = np  # cpu mode only here
+    s1 = np.load(test_path.joinpath('my_conv2_input.npy'))
+    s0 = np.copy(s1)
+    tmax = np.ceil(4 * sig)
+    dt = cp.arange(-tmax, tmax + 1)
+    gauss = cp.exp(-dt ** 2 / (2 * sig ** 2))
+    gauss = (gauss / cp.sum(gauss)).astype(np.float32)
+
+    cNorm = lfilter_cpu(gauss, 1., np.r_[np.ones(s1.shape[0]), np.zeros(int(tmax))])
+    cNorm = cNorm[int(tmax):]
+
+    s1 = lfilter_cpu(gauss, 1, np.r_[s1, np.zeros((int(tmax), s1.shape[1]))], axis=0)
+    s1 = s1[int(tmax):] / cNorm[:, np.newaxis]
+
+    # import matplotlib.pyplot as plt
+    # plt.plot(s0)
+    # plt.plot(s1)
+    # np.save(test_path.joinpath('my_conv2_input.npy'), s0)
+    np.save(test_path.joinpath('my_conv2_output.npy'), s1)

--- a/pykilosort/tests/test_utils.py
+++ b/pykilosort/tests/test_utils.py
@@ -1,0 +1,108 @@
+import numpy as np
+from numpy.testing import assert_array_equal as ae
+from numpy.testing import assert_allclose as ac
+from pytest import raises
+
+from ..utils import Context, LargeArrayWriter, memmap_large_array, save_large_array, NpyWriter
+
+
+def test_context_1(tmp_path):
+    arr = np.random.randn(10, 20)
+
+    c = Context(tmp_path)
+    c.intermediate.test1 = arr
+
+    ae(c.read('test1'), arr)
+
+    c.write(test1=arr)
+    ae(c.read('test1'), arr)
+
+    c.write(test2=12.34)
+    assert c.read('test2') == 12.34
+
+
+def test_context_2(tmp_path):
+    arr = np.random.randn(10, 20)
+
+    c = Context(tmp_path)
+
+    c.intermediate.test1 = arr
+    c.intermediate.test2 = 12.34
+    c.save()
+
+    c.load()
+    ae(c.intermediate.test1, arr)
+    assert c.intermediate.test2 == 12.34
+
+    c = Context(tmp_path)
+    assert 'test1' not in c.intermediate
+    c.load()
+    ae(c.intermediate.test1, arr)
+    assert c.intermediate.test2 == 12.34
+
+
+def test_large_array_1(tmp_path):
+    path = tmp_path / 'arr.dat'
+    arr = np.random.rand(1000, 13).T
+
+    law = LargeArrayWriter(path, dtype=arr.dtype, shape=(13, -1))
+    with raises(AssertionError):
+        law.append(np.random.rand(1000, 13))
+    law.append(arr)
+    law.close()
+
+    arr_1 = memmap_large_array(path)
+    assert arr_1.shape == arr.shape
+    ac(arr_1, arr)
+
+
+def test_large_array_2(tmp_path):
+    path = tmp_path / 'arr.dat'
+    arr = np.random.rand(1000, 13).T
+
+    law = LargeArrayWriter(path, dtype=arr.dtype, shape=(13, -1))
+    k = 10
+    for i in range(arr.shape[-1] // k):
+        law.append(arr[:, k * i: k * (i + 1)])
+    law.close()
+
+    arr_1 = memmap_large_array(path)
+    assert arr_1.shape == arr.shape
+    ac(arr_1, arr)
+
+
+def test_large_array_3(tmp_path):
+    path = tmp_path / 'arr.dat'
+
+    law = LargeArrayWriter(path, dtype=np.float32, shape=(13, -1))
+    arrs = []
+    for i in range(100):
+        arr = np.random.rand(np.random.randint(low=10, high=20), 13).T
+        arrs.append(arr)
+        law.append(arr)
+    law.close()
+
+    arr = np.concatenate(arrs, axis=1)
+    arr_1 = memmap_large_array(path)
+    assert arr_1.shape == arr.shape
+    ac(arr_1, arr)
+
+
+def test_save_large_array_1(tmp_path):
+    path = tmp_path / 'arr.npy'
+    for n in (0, 51, 99, 100, 101, 99, 1000, 1010):
+        array = np.random.rand(n, 20, 30)
+        with open(path, 'wb') as fp:
+            save_large_array(fp, array)
+        ac(np.load(path), array)
+
+
+def test_npy_writer_1(tmp_path):
+    path = tmp_path / 'arr.npy'
+    for n in (0, 51, 99, 100, 101, 99, 1000, 1010):
+        array = np.random.rand(n, 20, 30)
+        nw = NpyWriter(path, array.shape, array.dtype)
+        for row in array:
+            nw.append(row)
+        nw.close()
+        ac(np.load(path), array)

--- a/pykilosort/utils.py
+++ b/pykilosort/utils.py
@@ -1,0 +1,383 @@
+from contextlib import contextmanager
+from functools import reduce
+import json
+import logging
+from math import ceil
+from pathlib import Path
+import operator
+import os.path as op
+import re
+from time import perf_counter
+
+from tqdm import tqdm
+import numpy as np
+from numpy.lib.format import (
+    _check_version, _write_array_header, header_data_from_array_1_0, dtype_to_descr)
+import cupy as cp
+
+from .event import emit, connect, unconnect  # noqa
+
+logger = logging.getLogger(__name__)
+
+
+def prod(iterable):
+    return reduce(operator.mul, iterable, 1)
+
+
+class Bunch(dict):
+    """A subclass of dictionary with an additional dot syntax."""
+    def __init__(self, *args, **kwargs):
+        super(Bunch, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+    def copy(self):
+        """Return a new Bunch instance which is a copy of the current Bunch instance."""
+        return Bunch(super(Bunch, self).copy())
+
+
+def p(x):
+    print("shape", x.shape, "mean", "%5e" % x.mean())
+    print(x[:2, :2])
+    print()
+    print(x[-2:, -2:])
+
+
+def _extend(x, i0, i1, val, axis=0):
+    """Extend an array along a dimension and fill it with some values."""
+    shape = x.shape
+    if x.shape[axis] < i1:
+        s = list(x.shape)
+        s[axis] = i1 - s[axis]
+        x = cp.concatenate((x, cp.zeros(tuple(s), dtype=x.dtype, order='F')), axis=axis)
+        assert x.shape[axis] == i1
+    s = [slice(None, None, None)] * x.ndim
+    s[axis] = slice(i0, i1, 1)
+    x[s] = val
+    for i in range(x.ndim):
+        if i != axis:
+            assert x.shape[i] == shape[i]
+    return x
+
+
+def is_fortran(x):
+    if isinstance(x, np.ndarray):
+        return x.flags.f_contiguous
+    raise ValueError()
+
+
+def _make_fortran(x):
+    if 'dask' in str(x.__class__):
+        x = x.compute()
+    if isinstance(x, cp.ndarray):
+        x = cp.asnumpy(x)
+    return np.asfortranarray(x)
+
+
+def read_data(dat_path, offset=0, shape=None, dtype=None, axis=0):
+    count = shape[0] * shape[1] if shape and -1 not in shape else -1
+    buff = np.fromfile(dat_path, dtype=dtype, count=count, offset=offset)
+    if shape and -1 not in shape:
+        shape = (-1, shape[1]) if axis == 0 else (shape[0], -1)
+    if shape:
+        buff = buff.reshape(shape, order='F')
+    return buff
+
+
+def memmap_binary_file(dat_path, n_channels=None, shape=None, dtype=None, offset=None):
+    """Memmap a dat file in FORTRAN order, shape (n_channels, n_samples)."""
+    assert dtype is not None
+    item_size = np.dtype(dtype).itemsize
+    offset = offset if offset else 0
+    if shape is None:
+        assert n_channels is not None
+        n_samples = (op.getsize(str(dat_path)) - offset) // (item_size * n_channels)
+        shape = (n_channels, n_samples)
+    assert shape
+    shape = tuple(shape)
+    return np.memmap(str(dat_path), dtype=dtype, shape=shape, offset=offset, order='F')
+
+
+def extract_constants_from_cuda(code):
+    r = re.compile(r'const int\s+\S+\s+=\s+\S+.+')
+    m = r.search(code)
+    if m:
+        constants = m.group(0).replace('const int', '').replace(';', '').split(',')
+        for const in constants:
+            a, b = const.strip().split('=')
+            yield a.strip(), int(b.strip())
+
+
+def get_cuda(fn):
+    path = Path(__file__).parent / 'cuda' / (fn + '.cu')
+    assert path.exists
+    code = path.read_text()
+    code = code.replace('__global__ void', 'extern "C" __global__ void')
+    return code, Bunch(extract_constants_from_cuda(code))
+
+
+class LargeArrayWriter(object):
+    """Save a large array chunk by chunk, in a binary file with FORTRAN order."""
+    def __init__(self, path, dtype=None, shape=None):
+        self.path = Path(path)
+        self.dtype = np.dtype(dtype)
+        self._shape = shape
+        assert shape[-1] == -1  # the last axis must be the extendable axis, in FORTRAN order
+        assert -1 not in shape[:-1]  # shape may not contain -1 outside the last dimension
+        self.fw = open(self.path, 'wb')
+        self.extendable_axis_size = 0
+        self.total_size = 0
+
+    def append(self, arr):
+        # We convert to the requested data type.
+        assert arr.flags.f_contiguous  # only FORTRAN order arrays are currently supported
+        assert arr.shape[:-1] == self._shape[:-1]
+        arr = arr.astype(self.dtype)
+        es = arr.shape[-1]
+        if arr.flags.f_contiguous:
+            arr = arr.T
+        # We download the array from the GPU if required.
+        # We ensure the array is in FORTRAN order now.
+        assert arr.flags.c_contiguous
+        if isinstance(arr, cp.ndarray):
+            arr = cp.asnumpy(arr)
+        arr.tofile(self.fw)
+        self.total_size += arr.size
+        self.extendable_axis_size += es  # the last dimension, but
+        assert prod(self.shape) == self.total_size
+
+    @property
+    def shape(self):
+        return self._shape[:-1] + (self.extendable_axis_size,)
+
+    def close(self):
+        self.fw.close()
+        # Save JSON metadata file.
+        with open(self.path.with_suffix('.json'), 'w') as f:
+            json.dump({'shape': self.shape, 'dtype': str(self.dtype), 'order': 'F'}, f)
+
+
+def memmap_large_array(path):
+    """Memmap a large array saved by LargeArrayWriter."""
+    path = Path(path)
+    with open(path.with_suffix('.json'), 'r') as f:
+        metadata = json.load(f)
+    assert metadata['order'] == 'F'
+    dtype = np.dtype(metadata['dtype'])
+    shape = metadata['shape']
+    return memmap_binary_file(path, shape=shape, dtype=dtype)
+
+
+def _npy_header(shape, dtype, order='C'):
+    d = {'shape': shape}
+    if order == 'C':
+        d['fortran_order'] = False
+    elif order == 'F':
+        d['fortran_order'] = True
+    else:
+        # Totally non-contiguous data. We will have to make it C-contiguous
+        # before writing. Note that we need to test for C_CONTIGUOUS first
+        # because a 1-D array is both C_CONTIGUOUS and F_CONTIGUOUS.
+        d['fortran_order'] = False
+
+    d['descr'] = dtype_to_descr(dtype)
+    return d
+
+
+def save_large_array(fp, array, axis=0, desc=None):
+    """Save a large, potentially memmapped array, into a NPY file, chunk by chunk to avoid loading
+    it entirely in memory."""
+    assert axis == 0  # TODO: support other axes
+    version = None
+    _check_version(version)
+    _write_array_header(fp, header_data_from_array_1_0(array), version)
+    N = array.shape[axis]
+    if N == 0:
+        return
+
+    k = int(ceil(float(N) / 100))  # 100 chunks
+    assert k >= 1
+    for i in tqdm(range(0, N, k), desc=desc):
+        chunk = array[i:i + k, ...]
+        fp.write(chunk.tobytes())
+
+
+class NpyWriter(object):
+    def __init__(self, path, shape, dtype, axis=0):
+        assert axis == 0  # only concatenation along the first axis is supported right now
+        # Only C order is supported at the moment.
+        self.shape = shape
+        self.dtype = np.dtype(dtype)
+        header = _npy_header(self.shape, self.dtype)
+        version = None
+        _check_version(version)
+        self.fp = open(path, 'wb')
+        _write_array_header(self.fp, header, version)
+
+    def append(self, chunk):
+        if chunk.ndim == len(self.shape):
+            assert chunk.shape[1:] == self.shape[1:]
+        else:
+            assert chunk.shape == self.shape[1:]
+        self.fp.write(cp.asnumpy(chunk).tobytes())
+
+    def close(self):
+        self.fp.close()
+
+
+class Context(Bunch):
+    def __init__(self, context_path):
+        super(Context, self).__init__()
+        self.context_path = context_path
+        self.intermediate = Bunch()
+        self.context_path.mkdir(exist_ok=True, parents=True)
+        self.timer = {}
+
+    @property
+    def metadata_path(self):
+        return self.context_path / 'metadata.json'
+
+    def path(self, name, ext='.npy'):
+        """Path to an array in the context directory."""
+        return self.context_path / (name + ext)
+
+    def read_metadata(self):
+        """Read the metadata dictionary from the metadata.json file in the context dir."""
+        if not self.metadata_path.exists():
+            return Bunch()
+        with open(self.metadata_path, 'r') as f:
+            return Bunch(json.load(f))
+
+    def write_metadata(self, metadata):
+        """Write metadata dictionary in the metadata.json file."""
+        with open(self.metadata_path, 'w') as f:
+            json.dump(metadata, f, indent=2)
+
+    def read(self, name):
+        """Read an array from memory (intermediate object) or from disk."""
+        if name not in self.intermediate:
+            path = self.path(name)
+            # Load a NumPy file.
+            if path.exists():
+                logger.debug("Loading %s.npy", name)
+                # Memmap for large files.
+                mmap_mode = 'r' if op.getsize(path) > 1e8 else None
+                self.intermediate[name] = np.load(path, mmap_mode=mmap_mode)
+            else:
+                # Load a value from the metadata file.
+                self.intermediate[name] = self.read_metadata().get(name, None)
+        return self.intermediate[name]
+
+    def write(self, **kwargs):
+        """Write several arrays."""
+        # Load the metadata.
+        if self.metadata_path.exists():
+            metadata = self.read_metadata()
+        else:
+            metadata = Bunch()
+        # Write all variables.
+        for k, v in kwargs.items():
+            # Transfer GPU arrays to the CPU before saving them.
+            if isinstance(v, cp.ndarray):
+                logger.debug("Loading %s from GPU.", k)
+                v = cp.asnumpy(v)
+            if isinstance(v, np.ndarray):
+                p = self.path(k)
+                overwrite = ' (overwrite)' if p.exists() else ''
+                logger.debug("Saving %s.npy%s", k, overwrite)
+                np.save(p, np.asfortranarray(v))
+            elif v is not None:
+                logger.debug("Save %s in the metadata.json file.", k)
+                metadata[k] = v
+        # Write the metadata file.
+        self.write_metadata(metadata)
+
+    def load(self):
+        """Load intermediate results from disk."""
+        # Load metadata values that are not already loaded in the intermediate dictionary.
+        self.intermediate.update(
+            {k: v for k, v in self.read_metadata().items() if k not in self.intermediate})
+        # Load NumPy arrays that are not already loaded in the intermediate dictionary.
+        names = [f.stem for f in self.context_path.glob('*.npy')]
+        self.intermediate.update(
+            {name: self.read(name) for name in names if name not in self.intermediate})
+
+    def save(self, **kwargs):
+        """Save intermediate results to the ctx.intermediate dictionary, and to disk also.
+
+        This has two effects:
+        1. variables are available via ctx.intermediate in the current session
+        2. In a future session with ctx.load(), these variables will be readily available in
+           ctx.intermediate
+
+        """
+        for k, v in kwargs.items():
+            if v is not None:
+                self.intermediate[k] = v
+        kwargs = kwargs or self.intermediate
+        self.write(**kwargs)
+
+    @contextmanager
+    def time(self, name):
+        """Context manager to measure the time of a section of code."""
+        logger.info("Starting step %s.", name)
+        t0 = perf_counter()
+        yield
+        t1 = perf_counter()
+        self.timer[name] = t1 - t0
+        self.show_timer(name)
+
+    def show_timer(self, name=None):
+        """Display the results of the timer."""
+        if name:
+            logger.info("Step `{:s}` took {:.2f}s.".format(name, self.timer[name]))
+            return
+        for name in self.timer.keys():
+            self.show_timer(name)
+
+
+def load_probe(probe_path):
+    """Load a .mat probe file from Kilosort2, or a PRB file (experimental)."""
+
+    # A bunch with the following attributes:
+    _required_keys = ('NchanTOT', 'chanMap', 'xc', 'yc', 'kcoords')
+    probe = Bunch()
+    probe.NchanTOT = 0
+    probe_path = Path(probe_path).resolve()
+
+    if probe_path.suffix == '.prb':
+        # Support for PRB files.
+        contents = probe_path.read_text()
+        metadata = {}
+        exec(contents, {}, metadata)
+        probe.chanMap = []
+        probe.xc = []
+        probe.yc = []
+        probe.kcoords = []
+        for cg in sorted(metadata['channel_groups']):
+            d = metadata['channel_groups'][cg]
+            ch = d['channels']
+            pos = d.get('geometry', {})
+            probe.chanMap.append(ch)
+            probe.NchanTOT += len(ch)
+            probe.xc.append([pos[c][0] for c in ch])
+            probe.yc.append([pos[c][1] for c in ch])
+            probe.kcoords.append([cg for c in ch])
+        probe.chanMap = np.concatenate(probe.chanMap).ravel().astype(np.int32)
+        probe.xc = np.concatenate(probe.xc)
+        probe.yc = np.concatenate(probe.yc)
+        probe.kcoords = np.concatenate(probe.kcoords)
+
+    elif probe_path.suffix == '.mat':
+        from scipy.io import loadmat
+        mat = loadmat(probe_path)
+        probe.xc = mat['xcoords'].ravel().astype(np.float64)
+        nc = len(probe.xc)
+        probe.yc = mat['ycoords'].ravel().astype(np.float64)
+        probe.kcoords = mat.get('kcoords', np.zeros(nc)).ravel().astype(np.float64)
+        probe.chanMap = (mat['chanMap'] - 1).ravel().astype(np.int32)  # NOTE: 0-indexing in Python
+        probe.NchanTOT = len(probe.chanMap)  # NOTE: should match the # of columns in the raw data
+
+    for n in _required_keys:
+        assert n in probe.keys()
+
+    return probe

--- a/pyks2.yml
+++ b/pyks2.yml
@@ -1,0 +1,12 @@
+name: pyks2
+channels:
+  - defaults
+dependencies:
+ - python >=3.7
+ - scipy
+ - numpy
+ - cupy
+ - matplotlib
+ - tqdm
+ - click
+ - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+click
+cupy-cuda91
+matplotlib
+numba
+numpy
+pytest
+scipy
+tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,36 @@
+[wheel]
+universal = 1
+
+[tool:pytest]
+norecursedirs = experimental _*
+filterwarnings =
+    default
+    ignore::DeprecationWarning:.*
+    ignore:numpy.ufunc
+
+[flake8]
+ignore=E265,E731,E741,W504,W605
+max-line-length=99
+
+[coverage:run]
+branch = False
+source = phy
+omit =
+    */phy/ext/*
+    */phy/utils/tempdir.py
+    */default_settings.py
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    raise AssertionError
+    raise NotImplementedError
+    pass
+    continue
+    qtbot.stop()
+    _in_travis():
+    _is_high_dpi():
+    return$
+    ^"""
+omit =
+show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+"""Installation script."""
+
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+import os
+import os.path as op
+from pathlib import Path
+import re
+
+from setuptools import setup
+
+
+#------------------------------------------------------------------------------
+# Setup
+#------------------------------------------------------------------------------
+
+def _package_tree(pkgroot):
+    path = op.dirname(__file__)
+    subdirs = [op.relpath(i[0], path).replace(op.sep, '.')
+               for i in os.walk(op.join(path, pkgroot))
+               if '__init__.py' in i[2]]
+    return subdirs
+
+
+readme = (Path(__file__).parent / 'README.md').read_text()
+
+
+# Find version number from `__init__.py` without executing it.
+with (Path(__file__).parent / 'pykilosort/__init__.py').open('r') as f:
+    version = re.search(r"__version__ = '([^']+)'", f.read()).group(1)
+
+
+setup(
+    name='pykilosort',
+    version=version,
+    license="BSD",
+    description='Python port of KiloSort 2',
+    long_description=readme,
+    author='Cyrille Rossant',
+    author_email='cyrille.rossant@gmail.com',
+    url='https://github.com/rossant/pykilosort',
+    packages=_package_tree('pykilosort'),
+    package_dir={'pykilosort': 'pykilosort'},
+    package_data={
+        'pykilosort': [],
+    },
+    include_package_data=True,
+    keywords='kilosort,spike sorting,electrophysiology,neuroscience',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        "Framework :: IPython",
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+    ],
+    entry_points={
+        'console_scripts': [
+            'kilosort = pykilosort.gui:kilosort'
+        ],
+    },
+)


### PR DESCRIPTION
This pull request provides a merge of the [rossant/pykilosort](https://github.com/rossant/pykilosort) repository, containing an experimental Python port of Kilosort 2, into @marius10p's master Kilosort2 repository. The merge was done with git [following these instructions](https://stackoverflow.com/a/21353836/1595060).

The Python version is found in the `pykilosort/` subdirectory. This version is not ready for production yet. The README of pykilosort hasn't been merged at the moment.

* Line-by-line port from MATLAB into Python of the core implementation
* CUDA kernels have been kept completely untouched
* CuPy has been heavily used to match MATLAB's heavy use of GPU array and matrix operations
* CuPy was missing some features used by the MATLAB implementation (eg the median), most importantly an efficient GPU implementation of `lfilter()`. Effort has been done, in collaboration with @oliche, to make a scalable, memory-efficient, and fast FFT-based convolution of arbitrarily long multichannel time series.
* Development has been done using 2 excerpts datasets of 100s and 1000s from a Neuropixels 384-channel recording 
* On these test datasets, performance was grossly but not perfectly similar in terms of sorting quality and time performance
* Validation with a sort of ground-truth dataset has not yet been performed.