### PR TITLE
Fix for short runs, correct indexing when last cluster has no spikes

### DIFF
--- a/CUDA/mexMPnu8.cu
+++ b/CUDA/mexMPnu8.cu
@@ -941,13 +941,15 @@ void mexFunction(int nlhs, mxArray *plhs[],
   
   // loop to find and subtract spikes
   
-  double *d_draw64;        
+  double *d_draw64;    
+#ifndef ENSURE_DETERM
   if (useStableMode) {
       // create copy of the dataraw, d_dout, d_data as doubles for arithmetic
       // number of consecutive points to convert = Params(17) (Params(18) in matlab)         
       cudaMalloc(&d_draw64, NT*Nchan * sizeof(double));
       convToDouble<<<100,Nthreads>>>(d_Params, d_draw, d_draw64);  
   }
+#endif
 
   for(int k=0;k<(int) Params[3];k++){    //Parms[3] = nInnerIter, set to 60 final pass
       // ignore peaks that are smaller than another nearby peak
@@ -1046,11 +1048,13 @@ void mexFunction(int nlhs, mxArray *plhs[],
       // spikes will be added to d_featPC and then subracted out of d_out.
       cudaMemcpy(d_counter+1, d_counter, sizeof(int), cudaMemcpyDeviceToDevice);
   }
-  
+
+#ifndef ENSURE_DETERM
   if (useStableMode) {
     //convert arrays back to singles for the rest of the process
     convToSingle<<<100,Nthreads>>>(d_Params, d_draw64, d_draw);
   }
+#endif
 
   // compute PC features from reziduals + subtractions
   if (Params[12]>0)

--- a/mainLoop/runTemplates.m
+++ b/mainLoop/runTemplates.m
@@ -79,7 +79,7 @@ Nfilt = size(rez.W,2);
 Nchan = rez.ops.Nchan;
 nt0 = rez.ops.nt0;
 
-nKeep = min(Nchan*3,20); % how many PCs to keep
+nKeep = min([Nchan*3,Nbatches,20]); % how many PCs to keep
 rez.W_a = zeros(nt0 * Nrank, nKeep, Nfilt, 'single');
 rez.W_b = zeros(Nbatches, nKeep, Nfilt, 'single');
 rez.U_a = zeros(Nchan* Nrank, nKeep, Nfilt, 'single');

--- a/postProcess/set_cutoff.m
+++ b/postProcess/set_cutoff.m
@@ -8,10 +8,12 @@ function rez = set_cutoff(rez)
 ops = rez.ops;
 dt = 1/1000; % step size for CCG binning
 
-Nk = max(rez.st3(:,2)); % number of templates
+Nk = numel(rez.mu); % number of templates
 
 % sort by firing rate first
 rez.good = zeros(Nk, 1);
+rez.est_contam_rate = ones(Nk, 1);
+
 for j = 1:Nk
     ix = find(rez.st3(:,2)==j); % find all spikes from this neuron
     ss = rez.st3(ix,1)/ops.fs; % convert to seconds

--- a/utils/rezToPhy.m
+++ b/utils/rezToPhy.m
@@ -91,6 +91,7 @@ spikeAmps = tempAmpsUnscaled(spikeTemplates).*amplitudes;
 % tempScalingAmps are equal mean for all templates)
 ta = clusterAverage(spikeTemplates, spikeAmps);
 tids = unique(spikeTemplates);
+tempAmps = zeros(numel(rez.mu),1);
 tempAmps(tids) = ta; % because ta only has entries for templates that had at least one spike
 gain = getOr(rez.ops, 'gain', 1);
 tempAmps = gain*tempAmps'; % for consistency, make first dimension template number


### PR DESCRIPTION
In runTemplates, don't save more PCs than time batchs
In postProcess and rezToPhy, allocate arrays to ensure summary measures are
specified for highest index cluster even if it has no spikes.

Important bug fix in mexmpnu8 -- skip conversion to/from doubles when ENSURE_DETERM compile switch is set.