### PR TITLE
Change to how make_eMouseData_drift handles default paths for non-Windows/Linux compatibility

### DIFF
--- a/eMouse_drift/make_eMouseData_drift.m
+++ b/eMouse_drift/make_eMouseData_drift.m
@@ -50,9 +50,9 @@ useDefault = 1;     %use waveforms from eMouse folder in KS2
 
 if useDefault
     %get waveforms from eMouse folder in KS2
-     filePath{1} = [KS2path,'\eMouse_drift\','kampff_St_unit_waves_allNeg_2X.mat'];
+     filePath{1} = fullfile(KS2path,'eMouse_drift','kampff_St_unit_waves_allNeg_2X.mat');
      fileCopies(1) = 2;
-     filePath{2} = [KS2path,'\eMouse_drift\','121817_SU_waves_allNeg_gridEst.mat'];
+     filePath{2} = fullfile(KS2path,'eMouse_drift','121817_SU_waves_allNeg_gridEst.mat');
      fileCopies(2) = 2;
 else
     %fill in paths to waveform files 


### PR DESCRIPTION
make_eMouseData_drift currently constructs paths to waveform files in a way that assumes that the function is being run on a Windows machine.  This patch provides a more platform-neutral way of doing this.